### PR TITLE
modal drawer and alertdialog aria tests

### DIFF
--- a/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
@@ -7,7 +7,7 @@ import { useId, wrapEvent } from '@/packages/chakra-ui-core/src/utils'
 jest.mock('@/packages/chakra-ui-core/src/utils/dom.js')
 jest.mock('@/packages/chakra-ui-core/src/utils/generators.js')
 jest.mock('v-scroll-lock', () => ({}))
-jest.mock('breadstick/dist/components/Alert/styles.css', () => ({}))
+jest.mock('@/packages/chakra-ui-core/src/Toast/index.js', () => {})
 
 const renderComponent = (props) => {
   const inlineAttrs = (props && props.inlineAttrs) || ''

--- a/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
@@ -96,8 +96,6 @@ test('clicking overlay calls the onClose callback', async () => {
   expect(onClose).toHaveBeenCalled()
 })
 
-// TODO: A11y
-// ⚠️ remove skip
 it('should have proper aria', async () => {
   useId.mockReturnValueOnce('1')
   const inlineAttrs = 'isOpen'

--- a/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
@@ -1,5 +1,5 @@
 import { Button, AlertDialog, AlertDialogContent, AlertDialogBody, AlertDialogFooter, AlertDialogOverlay, AlertDialogHeader, Portal } from '../../'
-import { render, defaultProviders, userEvent, fireEvent } from '@/tests/test-utils'
+import { render, defaultProviders, userEvent, fireEvent, waitMs } from '@/tests/test-utils'
 import Vue from 'vue'
 import { useId, wrapEvent } from '@/packages/chakra-ui-core/src/utils'
 
@@ -98,17 +98,17 @@ test('clicking overlay calls the onClose callback', async () => {
 
 // TODO: A11y
 // ⚠️ remove skip
-it.skip('should have proper aria', async () => {
+it('should have proper aria', async () => {
+  useId.mockReturnValueOnce('1')
   const inlineAttrs = 'isOpen'
-  const { getByTestId } = renderComponent({ inlineAttrs })
+  renderComponent({ inlineAttrs })
 
   await Vue.nextTick()
-  const dialog = getByTestId('content') // eslint-disable-line
+  const dialog = document.querySelector('section') // eslint-disable-line
+  await waitMs()
 
-  // TODO: A11y role dialog or alertdialog?
-  // expect(dialog).toHaveAttribute('role', 'dialog')
-  // TODO: A11y aria modal?
-  // expect(dialog).toHaveAttribute('aria-modal', 'true')
-  // TODO: describedBy?
-  // expect(dialog).toHaveAttribute('aria-describedby', 'chakra-dialog--body-3')
+  expect(dialog).toHaveAttribute('role', 'alertdialog')
+  expect(dialog).toHaveAttribute('aria-modal', 'true')
+  expect(dialog).toHaveAttribute('aria-labelledby', 'alert-dialog-1-label')
+  expect(dialog).toHaveAttribute('aria-describedby', 'alert-dialog-1-desc')
 })

--- a/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/AlertDialog.test.js
@@ -102,7 +102,7 @@ it('should have proper aria', async () => {
   renderComponent({ inlineAttrs })
 
   await Vue.nextTick()
-  const dialog = document.querySelector('section') // eslint-disable-line
+  const dialog = document.querySelector('section')
   await waitMs()
 
   expect(dialog).toHaveAttribute('role', 'alertdialog')

--- a/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
@@ -31,12 +31,12 @@ exports[`should render correctly 1`] = `
             role="dialog"
             tabindex="-1"
           >
-            <div
+            <header
               class="css-kniazf"
               id="alert-dialog-1-label"
             >
               Dialog Header
-            </div>
+            </header>
              
             <div
               class="css-5m10fw"

--- a/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
@@ -22,7 +22,6 @@ exports[`should render correctly 1`] = `
         <div
           class="css-aibg9d"
           data-testid="overlay"
-          role="alertdialog"
         >
           <section
             aria-describedby="alert-dialog-1-desc"
@@ -30,7 +29,7 @@ exports[`should render correctly 1`] = `
             aria-modal="true"
             class="css-i76yoi"
             id="alert-dialog-1"
-            role="dialog"
+            role="alertdialog"
             tabindex="-1"
           >
             <header

--- a/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
@@ -25,6 +25,8 @@ exports[`should render correctly 1`] = `
           role="alertdialog"
         >
           <section
+            aria-describedby="alert-dialog-1-desc"
+            aria-labelledby="alert-dialog-1-label"
             aria-modal="true"
             class="css-i76yoi"
             id="alert-dialog-1"

--- a/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
+++ b/packages/chakra-ui-core/src/AlertDialog/tests/__snapshots__/AlertDialog.test.js.snap
@@ -2,63 +2,6 @@
 
 exports[`should render correctly 1`] = `
 <DocumentFragment>
-  <div
-    class="Breadstick"
-    id="breadstick-kitchen"
-  >
-    <span>
-      <span
-        class="Breadstick__manager-top"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-left"
-        style="position: fixed; z-index: 5500; top: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-right"
-        style="position: fixed; z-index: 5500; top: 0px; right: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-left"
-        style="position: fixed; z-index: 5500; bottom: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-right"
-        style="position: fixed; z-index: 5500; bottom: 0px; right: 0px;"
-      />
-    </span>
-    <span>
-      <span
-        class="Breadstick__manager-top"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-left"
-        style="position: fixed; z-index: 5500; top: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-right"
-        style="position: fixed; z-index: 5500; top: 0px; right: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-left"
-        style="position: fixed; z-index: 5500; bottom: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-right"
-        style="position: fixed; z-index: 5500; bottom: 0px; right: 0px;"
-      />
-    </span>
-  </div>
   <div>
     <div>
       <!---->

--- a/packages/chakra-ui-core/src/Drawer/tests/Drawer.test.js
+++ b/packages/chakra-ui-core/src/Drawer/tests/Drawer.test.js
@@ -7,7 +7,7 @@ import { useId, wrapEvent } from '@/packages/chakra-ui-core/src/utils'
 jest.mock('@/packages/chakra-ui-core/src/utils/dom.js')
 jest.mock('@/packages/chakra-ui-core/src/utils/generators.js')
 jest.mock('v-scroll-lock', () => ({}))
-jest.mock('breadstick/dist/components/Alert/styles.css', () => ({}))
+jest.mock('@/packages/chakra-ui-core/src/Toast/index.js', () => {})
 
 const renderComponent = (props) => {
   const inlineAttrs = (props && props.inlineAttrs) || ''

--- a/packages/chakra-ui-core/src/Drawer/tests/Drawer.test.js
+++ b/packages/chakra-ui-core/src/Drawer/tests/Drawer.test.js
@@ -129,7 +129,7 @@ it('should have proper aria', async () => {
   renderComponent({ inlineAttrs })
 
   await Vue.nextTick()
-  const dialog = document.querySelector('section') // eslint-disable-line
+  const dialog = document.querySelector('section')
   await waitMs()
 
   expect(dialog).toHaveAttribute('role', 'dialog')

--- a/packages/chakra-ui-core/src/Drawer/tests/Drawer.test.js
+++ b/packages/chakra-ui-core/src/Drawer/tests/Drawer.test.js
@@ -123,19 +123,17 @@ test('returns focus when closed - finalFocusRef', async () => {
   expect(inputOutside).toHaveFocus()
 })
 
-// TODO: A11y
-// ⚠️ remove skip
-it.skip('should have proper aria', async () => {
+it('should have proper aria', async () => {
+  useId.mockReturnValueOnce('1')
   const inlineAttrs = 'isOpen'
-  const { getByTestId } = renderComponent({ inlineAttrs })
+  renderComponent({ inlineAttrs })
 
   await Vue.nextTick()
-  const dialog = getByTestId('content') // eslint-disable-line
+  const dialog = document.querySelector('section') // eslint-disable-line
+  await waitMs()
 
-  // TODO: A11y role dialog or alertdialog?
-  // expect(dialog).toHaveAttribute('role', 'dialog')
-  // TODO: A11y aria modal?
-  // expect(dialog).toHaveAttribute('aria-modal', 'true')
-  // TODO: describedBy?
-  // expect(dialog).toHaveAttribute('aria-describedby', 'chakra-dialog--body-3')
+  expect(dialog).toHaveAttribute('role', 'dialog')
+  expect(dialog).toHaveAttribute('aria-modal', 'true')
+  expect(dialog).toHaveAttribute('aria-labelledby', 'drawer-1-header')
+  expect(dialog).toHaveAttribute('aria-describedby', 'drawer-1-body')
 })

--- a/packages/chakra-ui-core/src/Drawer/tests/__snapshots__/Drawer.test.js.snap
+++ b/packages/chakra-ui-core/src/Drawer/tests/__snapshots__/Drawer.test.js.snap
@@ -94,12 +94,12 @@ exports[`should render correctly 1`] = `
               </svg>
             </button>
              
-            <div
+            <header
               class="css-kniazf"
               id="drawer-1-header"
             >
               Create your account
-            </div>
+            </header>
              
             <div
               class="css-5m10fw"

--- a/packages/chakra-ui-core/src/Drawer/tests/__snapshots__/Drawer.test.js.snap
+++ b/packages/chakra-ui-core/src/Drawer/tests/__snapshots__/Drawer.test.js.snap
@@ -39,6 +39,8 @@ exports[`should render correctly 1`] = `
           data-testid="overlay"
         >
           <section
+            aria-describedby="drawer-1-body"
+            aria-labelledby="drawer-1-header"
             aria-modal="true"
             class="css-iv9bja"
             id="drawer-1"

--- a/packages/chakra-ui-core/src/Drawer/tests/__snapshots__/Drawer.test.js.snap
+++ b/packages/chakra-ui-core/src/Drawer/tests/__snapshots__/Drawer.test.js.snap
@@ -2,63 +2,6 @@
 
 exports[`should render correctly 1`] = `
 <DocumentFragment>
-  <div
-    class="Breadstick"
-    id="breadstick-kitchen"
-  >
-    <span>
-      <span
-        class="Breadstick__manager-top"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-left"
-        style="position: fixed; z-index: 5500; top: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-right"
-        style="position: fixed; z-index: 5500; top: 0px; right: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-left"
-        style="position: fixed; z-index: 5500; bottom: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-right"
-        style="position: fixed; z-index: 5500; bottom: 0px; right: 0px;"
-      />
-    </span>
-    <span>
-      <span
-        class="Breadstick__manager-top"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-left"
-        style="position: fixed; z-index: 5500; top: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-right"
-        style="position: fixed; z-index: 5500; top: 0px; right: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-left"
-        style="position: fixed; z-index: 5500; bottom: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-right"
-        style="position: fixed; z-index: 5500; bottom: 0px; right: 0px;"
-      />
-    </span>
-  </div>
   <div>
     <div>
       <input

--- a/packages/chakra-ui-core/src/Modal/index.js
+++ b/packages/chakra-ui-core/src/Modal/index.js
@@ -73,7 +73,7 @@ const Modal = {
       this.addAriaDescribedby = this.addAriaLabels['body']
     }
 
-    if (typeof addAriaLabels === 'boolean') {
+    if (typeof this.addAriaLabels === 'boolean') {
       this.addAriaLabelledby = this.addAriaLabels
       this.addAriaDescribedby = this.addAriaLabels
     }

--- a/packages/chakra-ui-core/src/Modal/index.js
+++ b/packages/chakra-ui-core/src/Modal/index.js
@@ -253,6 +253,7 @@ const ModalOverlay = {
 
 const ModalContent = {
   name: 'ModalContent',
+  inheritAttrs: false,
   inject: ['$ModalContext', '$colorMode'],
   props: {
     ...baseProps,
@@ -409,7 +410,8 @@ const ModalContent = {
           tabIndex: -1,
           id: contentId,
           ...(addAriaDescribedby && { 'aria-describedby': bodyId }),
-          ...(addAriaLabelledby && { 'aria-labelledby': headerId })
+          ...(addAriaLabelledby && { 'aria-labelledby': headerId }),
+          ...this.$attrs
         },
         nativeOn: {
           click: wrapEvent((e) => this.$emit('click', e), event => event.stopPropagation())

--- a/packages/chakra-ui-core/src/Modal/index.js
+++ b/packages/chakra-ui-core/src/Modal/index.js
@@ -433,6 +433,7 @@ const ModalHeader = {
 
     return h(Box, {
       props: {
+        as: 'header',
         px: 6,
         py: 4,
         position: 'relative',

--- a/packages/chakra-ui-core/src/Modal/tests/Modal.test.js
+++ b/packages/chakra-ui-core/src/Modal/tests/Modal.test.js
@@ -7,7 +7,7 @@ import { useId, wrapEvent } from '@/packages/chakra-ui-core/src/utils'
 jest.mock('@/packages/chakra-ui-core/src/utils/dom.js')
 jest.mock('@/packages/chakra-ui-core/src/utils/generators.js')
 jest.mock('v-scroll-lock', () => ({}))
-jest.mock('breadstick/dist/components/Alert/styles.css', () => ({}))
+jest.mock('@/packages/chakra-ui-core/src/Toast/index.js', () => {})
 
 const renderComponent = (props) => {
   const inlineAttrs = (props && props.inlineAttrs) || ''

--- a/packages/chakra-ui-core/src/Modal/tests/Modal.test.js
+++ b/packages/chakra-ui-core/src/Modal/tests/Modal.test.js
@@ -129,7 +129,7 @@ it('should have proper aria', async () => {
   renderComponent({ inlineAttrs })
 
   await Vue.nextTick()
-  const dialog = document.querySelector('section') // eslint-disable-line
+  const dialog = document.querySelector('section')
   await waitMs()
 
   expect(dialog).toHaveAttribute('role', 'dialog')

--- a/packages/chakra-ui-core/src/Modal/tests/Modal.test.js
+++ b/packages/chakra-ui-core/src/Modal/tests/Modal.test.js
@@ -123,19 +123,17 @@ test('returns focus when closed - finalFocusRef', async () => {
   expect(inputOutside).toHaveFocus()
 })
 
-// TODO: A11y
-// ⚠️ remove skip
-it.skip('should have proper aria', async () => {
+it('should have proper aria', async () => {
+  useId.mockReturnValueOnce('1')
   const inlineAttrs = 'isOpen'
-  const { getByTestId } = renderComponent({ inlineAttrs })
+  renderComponent({ inlineAttrs })
 
   await Vue.nextTick()
-  const dialog = getByTestId('content') // eslint-disable-line
+  const dialog = document.querySelector('section') // eslint-disable-line
+  await waitMs()
 
-  // TODO: A11y role dialog or alertdialog?
-  // expect(dialog).toHaveAttribute('role', 'dialog')
-  // TODO: A11y aria modal?
-  // expect(dialog).toHaveAttribute('aria-modal', 'true')
-  // TODO: describedBy?
-  // expect(dialog).toHaveAttribute('aria-describedby', 'chakra-dialog--body-3')
+  expect(dialog).toHaveAttribute('role', 'dialog')
+  expect(dialog).toHaveAttribute('aria-modal', 'true')
+  expect(dialog).toHaveAttribute('aria-labelledby', 'modal-1-header')
+  expect(dialog).toHaveAttribute('aria-describedby', 'modal-1-body')
 })

--- a/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
+++ b/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
@@ -39,6 +39,8 @@ exports[`should render correctly 1`] = `
           data-testid="overlay"
         >
           <section
+            aria-describedby="modal-1-body"
+            aria-labelledby="modal-1-header"
             aria-modal="true"
             class="css-i76yoi"
             id="modal-1"

--- a/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
+++ b/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
@@ -36,13 +36,13 @@ exports[`should render correctly 1`] = `
         />
         <div
           class="css-aibg9d"
-          data-testid="overlay"
         >
           <section
             aria-describedby="modal-1-body"
             aria-labelledby="modal-1-header"
             aria-modal="true"
             class="css-i76yoi"
+            data-testid="overlay"
             id="modal-1"
             role="dialog"
             tabindex="-1"

--- a/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
+++ b/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
@@ -2,63 +2,6 @@
 
 exports[`should render correctly 1`] = `
 <DocumentFragment>
-  <div
-    class="Breadstick"
-    id="breadstick-kitchen"
-  >
-    <span>
-      <span
-        class="Breadstick__manager-top"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-left"
-        style="position: fixed; z-index: 5500; top: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-right"
-        style="position: fixed; z-index: 5500; top: 0px; right: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-left"
-        style="position: fixed; z-index: 5500; bottom: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-right"
-        style="position: fixed; z-index: 5500; bottom: 0px; right: 0px;"
-      />
-    </span>
-    <span>
-      <span
-        class="Breadstick__manager-top"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-left"
-        style="position: fixed; z-index: 5500; top: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-top-right"
-        style="position: fixed; z-index: 5500; top: 0px; right: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-left"
-        style="position: fixed; z-index: 5500; bottom: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom"
-        style="position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"
-      />
-      <span
-        class="Breadstick__manager-bottom-right"
-        style="position: fixed; z-index: 5500; bottom: 0px; right: 0px;"
-      />
-    </span>
-  </div>
   <div>
     <div>
       <input

--- a/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
+++ b/packages/chakra-ui-core/src/Modal/tests/__snapshots__/Modal.test.js.snap
@@ -94,12 +94,12 @@ exports[`should render correctly 1`] = `
               </svg>
             </button>
              
-            <div
+            <header
               class="css-kniazf"
               id="modal-1-header"
             >
               Create your account
-            </div>
+            </header>
              
             <div
               class="css-5m10fw"


### PR DESCRIPTION
Hey!

- changed modal header `div` to `header`
- mocked `Toast` since we dont need it in snapshots
- fixed modal aria labels
- fixed alertdialog aria labels
- added aria tests for drawer component