### PR TITLE
fix: made sure pages always starts from top when navigating

### DIFF
--- a/packages/chakra-ui-docs/router.js
+++ b/packages/chakra-ui-docs/router.js
@@ -34,6 +34,9 @@ export function createRouter () {
 
   const router = new Router({
     mode: 'history',
+    scrollBehavior (to, from, savedPosition) {
+      return { x: 0, y: 0 }
+    },
     routes
   })
 


### PR DESCRIPTION
## Description
Added the functionality for all docs pages to scroll to top
## Motivation and Context
By default while navigating to docs pages, the pages don't start from the top if you have scrolled before(Not quite a good UX)
