### PR TITLE
docs: Add missing CButton component import in nuxt doc

### DIFF
--- a/packages/chakra-ui-docs/docs/with-nuxt.mdx
+++ b/packages/chakra-ui-docs/docs/with-nuxt.mdx
@@ -59,13 +59,15 @@ import {
   name: 'DefaultLayout',
   CThemeProvider,
   CReset,
+  CButton
 } from "@chakra-ui/vue";
 
 export default {
   name: "App",
   components: {
     CThemeProvider,
-    CReset
+    CReset,
+    CButton
   }
 };
 </script>


### PR DESCRIPTION
The CButton component is missing an import in the example vue component, but is used in the template tag. 

## Motivation and Context
Just a little hiccup I encountered when getting up and running with Nuxt.

## How Has This Been Tested?
Tested and works.