### PR TITLE
fix: A typo error in color-mode.mdx file

### DIFF
--- a/packages/chakra-ui-docs/docs/color-mode.mdx
+++ b/packages/chakra-ui-docs/docs/color-mode.mdx
@@ -9,7 +9,7 @@ To enable toggling between Dark and Light modes within your apps, wrap your appl
 `CColorModeProvider` component. This component provides two variables in it's descendant's context using the
 [provide/inject](https://vuejs.org/v2/api/#provide-inject) API:
 - `$chakraColorMode` => This is a function that returns the current mode. Use it the computed property.
-- `$toggleColorMode` => This function toggles teh current color mode value.
+- `$toggleColorMode` => This function toggles the current color mode value.
 
 Below is an example of how to use the above variables:
 


### PR DESCRIPTION
Update a typo error on line 12 in color-mode.mdx file. It should be "the current color mode value" not "teh current color mode value".

