### PR TITLE
Default fontFamily prop to "body"

### DIFF
--- a/packages/chakra-ui-core/src/CAccordion/tests/__snapshots__/CAccordion.test.js.snap
+++ b/packages/chakra-ui-core/src/CAccordion/tests/__snapshots__/CAccordion.test.js.snap
@@ -3,24 +3,24 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CAccordion"
   >
     <div
-      class="css-0 css-1b3isn8"
+      class="css-fzcsno css-7seucn"
       data-chakra-component="CAccordionItem"
     >
       <button
         aria-controls="accordion-panel-ac-1"
         aria-expanded="true"
-        class="css-0 css-12lgae2"
+        class="css-fzcsno css-1gup8y1"
         data-chakra-component="CAccordionHeader"
         id="accordion-header-ac-1"
         type="button"
       >
         Section 1 title
         <svg
-          class="css-1yguofd css-y3asau"
+          class="css-u1drdl css-y3asau"
           data-chakra-component="CAccordionIcon"
           role="presentation"
           viewBox="0 0 24 24"
@@ -36,14 +36,14 @@ exports[`should render correctly 1`] = `
        
       <div
         aria-labelledby="accordion-header-ac-1"
-        class="css-i6bazn"
+        class="css-qiuzxw"
         data-chakra-component="CAccordionPanel"
         id="accordion-panel-ac-1"
         role="region"
         style="visibility: hidden; height: 0px;"
       >
         <div
-          class="css-11lffaa"
+          class="css-1lbvsw3"
           data-chakra-component="CBox"
         >
           Section 1 text

--- a/packages/chakra-ui-core/src/CAlert/tests/__snapshots__/CAlert.test.js.snap
+++ b/packages/chakra-ui-core/src/CAlert/tests/__snapshots__/CAlert.test.js.snap
@@ -8,7 +8,7 @@ exports[`should override icon if set explicitly 1`] = `
     role="alert"
   >
     <svg
-      class="css-9jzj25 css-y3asau"
+      class="css-1rzyopz css-y3asau"
       data-chakra-component="CAlertIcon"
       role="presentation"
       viewBox="0 0 24 24"
@@ -29,7 +29,7 @@ exports[`should override icon if set explicitly 1`] = `
 exports[`should render correct variant styles 1`] = `
 <DocumentFragment>
   <div
-    class="css-j7qwjs"
+    class="css-813bdq"
     data-chakra-component="CStack"
   >
     <div
@@ -38,7 +38,7 @@ exports[`should render correct variant styles 1`] = `
       role="alert"
     >
       <svg
-        class="css-1gbfvwr css-y3asau"
+        class="css-qer2jp css-y3asau"
         data-chakra-component="CAlertIcon"
         role="presentation"
         viewBox="0 0 24 24"
@@ -88,7 +88,7 @@ exports[`should render correct variant styles 1`] = `
       role="alert"
     >
       <svg
-        class="css-vpe47c css-y3asau"
+        class="css-15wmxy1 css-y3asau"
         data-chakra-component="CAlertIcon"
         role="presentation"
         viewBox="0 0 24 24"
@@ -138,7 +138,7 @@ exports[`should render correct variant styles 1`] = `
       role="alert"
     >
       <svg
-        class="css-1gbfvwr css-y3asau"
+        class="css-qer2jp css-y3asau"
         data-chakra-component="CAlertIcon"
         role="presentation"
         viewBox="0 0 24 24"
@@ -188,7 +188,7 @@ exports[`should render correct variant styles 1`] = `
       role="alert"
     >
       <svg
-        class="css-1gbfvwr css-y3asau"
+        class="css-qer2jp css-y3asau"
         data-chakra-component="CAlertIcon"
         role="presentation"
         viewBox="0 0 24 24"
@@ -244,7 +244,7 @@ exports[`should render correctly 1`] = `
     role="alert"
   >
     <svg
-      class="css-10jngok css-y3asau"
+      class="css-1114uxt css-y3asau"
       data-chakra-component="CAlertIcon"
       role="presentation"
       viewBox="0 0 24 24"
@@ -286,14 +286,14 @@ exports[`should render correctly 1`] = `
     </svg>
      
     <div
-      class="css-11a523j"
+      class="css-nl0mdx"
       data-chakra-component="CAlertTitle"
     >
       alert title
     </div>
      
     <div
-      class="css-0"
+      class="css-fzcsno"
       data-chakra-component="CAlertDescription"
     >
       alert description

--- a/packages/chakra-ui-core/src/CAlertDialog/tests/__snapshots__/CAlertDialog.test.js.snap
+++ b/packages/chakra-ui-core/src/CAlertDialog/tests/__snapshots__/CAlertDialog.test.js.snap
@@ -11,18 +11,18 @@ exports[`should render correctly 1`] = `
     id="modal-portal-1"
   >
     <div
-      class="css-0 css-79elbk"
+      class="css-fzcsno css-1w0sygx"
       data-chakra-component="CPseudoBox"
     >
       <div
         style="position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px;"
       >
         <div
-          class="css-l5w8ps"
+          class="css-1h6qt27"
           data-chakra-component="CBox"
         />
         <div
-          class="css-aibg9d"
+          class="css-tj90gg"
           data-chakra-component="CModalContent"
           data-testid="overlay"
         >
@@ -37,7 +37,7 @@ exports[`should render correctly 1`] = `
             tabindex="-1"
           >
             <header
-              class="css-kniazf"
+              class="css-cryb04"
               data-chakra-component="CModalHeader"
               id="alert-dialog-1-label"
             >
@@ -45,7 +45,7 @@ exports[`should render correctly 1`] = `
             </header>
              
             <div
-              class="css-5m10fw"
+              class="css-1lxlfxt"
               data-chakra-component="CModalBody"
               id="alert-dialog-1-desc"
             >
@@ -59,11 +59,11 @@ exports[`should render correctly 1`] = `
             </div>
              
             <footer
-              class="css-plnu2w"
+              class="css-1y6ww5m"
               data-chakra-component="CModalFooter"
             >
               <button
-                class="css-0 css-rup5mm"
+                class="css-fzcsno css-1240sfg"
                 data-chakra-component="CButton"
                 data-testid="close-btn"
                 tabindex="0"
@@ -73,7 +73,7 @@ exports[`should render correctly 1`] = `
               </button>
                
               <button
-                class="css-0 css-mbmse4"
+                class="css-fzcsno css-1uibj8n"
                 data-chakra-component="CButton"
                 tabindex="0"
                 type="button"

--- a/packages/chakra-ui-core/src/CAspectRatioBox/tests/__snapshots__/CAspectRatioBox.test.js.snap
+++ b/packages/chakra-ui-core/src/CAspectRatioBox/tests/__snapshots__/CAspectRatioBox.test.js.snap
@@ -3,13 +3,13 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-0 css-yotxfm"
+    class="css-fzcsno css-1a546fy"
     data-chakra-component="CAspectRatioBox"
     data-testid="aspectRatioBox"
   >
     <img
       alt="naruto"
-      class="css-1yxkji9"
+      class="css-fxtok7"
       data-chakra-component="CBox"
       data-testid="image"
       src="https://bit.ly/naruto-sage"

--- a/packages/chakra-ui-core/src/CAvatar/tests/__snapshots__/CAvatar.test.js.snap
+++ b/packages/chakra-ui-core/src/CAvatar/tests/__snapshots__/CAvatar.test.js.snap
@@ -3,13 +3,13 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-86yran"
+    class="css-2sxxyf"
     data-chakra-component="CAvatar"
     data-testid="avatar"
   >
     <div
       aria-label="Mesut Koca"
-      class="css-1e8yzjf"
+      class="css-1n1d9mc"
       data-chakra-component="CAvatarName"
     >
       MK
@@ -21,12 +21,12 @@ exports[`should render correctly 1`] = `
 exports[`should render default avatar if name is not provided and image didn't load 1`] = `
 <DocumentFragment>
   <div
-    class="css-n5i113"
+    class="css-7ezpv2"
     data-chakra-component="CAvatar"
     data-testid="avatar"
   >
     <div
-      class="css-14vc57m"
+      class="css-1clbu1k"
       data-chakra-component="CDefaultAvatar"
     >
       

--- a/packages/chakra-ui-core/src/CAvatarGroup/tests/__snapshots__/CAvatarGroup.test.js.snap
+++ b/packages/chakra-ui-core/src/CAvatarGroup/tests/__snapshots__/CAvatarGroup.test.js.snap
@@ -3,35 +3,35 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-80aj1h"
+    class="css-mbvt3n"
     data-chakra-component="CFlex"
   >
     <div
-      class="css-lv2eyz"
+      class="css-1jwki60"
       data-chakra-component="CAvatar"
     >
       <div
         aria-label="Mesut Koca"
-        class="css-1e8yzjf"
+        class="css-1n1d9mc"
         data-chakra-component="CAvatarName"
       >
         MK
       </div>
     </div>
     <div
-      class="css-o0a73u"
+      class="css-1li52eg"
       data-chakra-component="CAvatar"
     >
       <div
         aria-label="Evan You"
-        class="css-1e8yzjf"
+        class="css-1n1d9mc"
         data-chakra-component="CAvatarName"
       >
         EY
       </div>
     </div>
     <div
-      class="css-3dare1"
+      class="css-lpwrl7"
       data-chakra-component="CFlex"
     >
       +1

--- a/packages/chakra-ui-core/src/CBadge/tests/__snapshots__/CBadge.test.js.snap
+++ b/packages/chakra-ui-core/src/CBadge/tests/__snapshots__/CBadge.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should apply variant styles corectly 1`] = `
 <DocumentFragment>
   <div
-    class="css-1xhj18k"
+    class="css-jlqe4x"
     data-chakra-component="CStack"
   >
     <div

--- a/packages/chakra-ui-core/src/CBox/tests/__snapshots__/CBox.test.js.snap
+++ b/packages/chakra-ui-core/src/CBox/tests/__snapshots__/CBox.test.js.snap
@@ -15,7 +15,7 @@ exports[`should change the style 1`] = `
 exports[`should display CBox with type as header 1`] = `
 <DocumentFragment>
   <header
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CBox"
     data-testid="box"
   >
@@ -27,7 +27,7 @@ exports[`should display CBox with type as header 1`] = `
 exports[`should display CBox with type as p 1`] = `
 <DocumentFragment>
   <p
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CBox"
     data-testid="box"
   >
@@ -39,7 +39,7 @@ exports[`should display CBox with type as p 1`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CBox"
     data-testid="box"
   >

--- a/packages/chakra-ui-core/src/CBreadcrumb/tests/__snapshots__/CBreadcrumb.test.js.snap
+++ b/packages/chakra-ui-core/src/CBreadcrumb/tests/__snapshots__/CBreadcrumb.test.js.snap
@@ -4,26 +4,26 @@ exports[`should display custom seperator  1`] = `
 <DocumentFragment>
   <nav
     aria-label="breadcrumb"
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CBreadcrumb"
   >
     <ol
-      class="css-0"
+      class="css-fzcsno"
       data-chakra-component="CBox"
     >
       <li
-        class="css-18biwo"
+        class="css-juzgwo"
         data-chakra-component="CBreadcrumbItem"
       >
         <a
-          class="css-0 css-19ysyim"
+          class="css-fzcsno css-1v8ez2b"
           data-chakra-component="CBreadcrumbLink"
           href="/"
         >
           Home
         </a>
         <span
-          class="css-dp0f2t"
+          class="css-1d9u6m1"
           data-chakra-component="CBreadcrumbSeparator"
           role="presentation"
         >
@@ -31,18 +31,18 @@ exports[`should display custom seperator  1`] = `
         </span>
       </li>
       <li
-        class="css-18biwo"
+        class="css-juzgwo"
         data-chakra-component="CBreadcrumbItem"
       >
         <a
-          class="css-0 css-19ysyim"
+          class="css-fzcsno css-1v8ez2b"
           data-chakra-component="CBreadcrumbLink"
           href="/about"
         >
           About
         </a>
         <span
-          class="css-dp0f2t"
+          class="css-1d9u6m1"
           data-chakra-component="CBreadcrumbSeparator"
           role="presentation"
         >
@@ -50,12 +50,12 @@ exports[`should display custom seperator  1`] = `
         </span>
       </li>
       <li
-        class="css-18biwo"
+        class="css-juzgwo"
         data-chakra-component="CBreadcrumbItem"
       >
         <span
           aria-current="page"
-          class="css-0"
+          class="css-fzcsno"
           data-chakra-component="CBreadcrumbLink"
           href="/contact"
         >
@@ -72,26 +72,26 @@ exports[`should render correctly 1`] = `
   <div>
     <nav
       aria-label="breadcrumb"
-      class="css-0"
+      class="css-fzcsno"
       data-chakra-component="CBreadcrumb"
     >
       <ol
-        class="css-0"
+        class="css-fzcsno"
         data-chakra-component="CBox"
       >
         <li
-          class="css-18biwo"
+          class="css-juzgwo"
           data-chakra-component="CBreadcrumbItem"
         >
           <a
-            class="css-0 css-19ysyim"
+            class="css-fzcsno css-1v8ez2b"
             data-chakra-component="CBreadcrumbLink"
             href="#"
           >
             Breadcrumb 1
           </a>
           <span
-            class="css-6eovvf"
+            class="css-s9unhl"
             data-chakra-component="CBreadcrumbSeparator"
             role="presentation"
           >
@@ -99,18 +99,18 @@ exports[`should render correctly 1`] = `
           </span>
         </li>
         <li
-          class="css-18biwo"
+          class="css-juzgwo"
           data-chakra-component="CBreadcrumbItem"
         >
           <a
-            class="css-0 css-19ysyim"
+            class="css-fzcsno css-1v8ez2b"
             data-chakra-component="CBreadcrumbLink"
             href="#"
           >
             Breadcrumb 2
           </a>
           <span
-            class="css-1hgjpgb"
+            class="css-11al2zw"
             data-chakra-component="CBreadcrumbSeparator"
             role="presentation"
           >

--- a/packages/chakra-ui-core/src/CButton/tests/__snapshots__/CButton.test.js.snap
+++ b/packages/chakra-ui-core/src/CButton/tests/__snapshots__/CButton.test.js.snap
@@ -3,13 +3,13 @@
 exports[`should display button with left icon 1`] = `
 <DocumentFragment>
   <button
-    class="css-0 css-rup5mm"
+    class="css-fzcsno css-1240sfg"
     data-chakra-component="CButton"
     tabindex="0"
     type="button"
   >
     <svg
-      class="css-6lyqdc css-y3asau"
+      class="css-1vuvkvf css-y3asau"
       data-chakra-component="CButtonIcon"
       role="presentation"
       viewBox="0 0 24 24"
@@ -43,14 +43,14 @@ exports[`should display button with left icon 1`] = `
 exports[`should display button with right icon 1`] = `
 <DocumentFragment>
   <button
-    class="css-0 css-rup5mm"
+    class="css-fzcsno css-1240sfg"
     data-chakra-component="CButton"
     tabindex="0"
     type="button"
   >
     Email
     <svg
-      class="css-88m0n5 css-y3asau"
+      class="css-bgnibt css-y3asau"
       data-chakra-component="CButtonIcon"
       role="presentation"
       viewBox="0 0 24 24"
@@ -83,7 +83,7 @@ exports[`should display button with right icon 1`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <button
-    class="css-0 css-rup5mm"
+    class="css-fzcsno css-1240sfg"
     data-chakra-component="CButton"
     tabindex="0"
     type="button"

--- a/packages/chakra-ui-core/src/CButtonGroup/tests/__snapshots__/CButtonGroup.test.js.snap
+++ b/packages/chakra-ui-core/src/CButtonGroup/tests/__snapshots__/CButtonGroup.test.js.snap
@@ -3,11 +3,11 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-1baulvz"
+    class="css-1xn5gl6"
     data-chakra-component="CButtonGroup"
   >
     <button
-      class="css-0 css-1egt1u4"
+      class="css-fzcsno css-hz466c"
       data-chakra-component="CButton"
       tabindex="0"
       type="button"
@@ -15,7 +15,7 @@ exports[`should render correctly 1`] = `
       Button1
     </button>
     <button
-      class="css-0 css-pt9fef"
+      class="css-fzcsno css-bibkwt"
       data-chakra-component="CButton"
       tabindex="0"
       type="button"

--- a/packages/chakra-ui-core/src/CCheckbox/tests/__snapshots__/CCheckbox.test.js.snap
+++ b/packages/chakra-ui-core/src/CCheckbox/tests/__snapshots__/CCheckbox.test.js.snap
@@ -3,12 +3,12 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <label
-    class="css-1qf83f9"
+    class="css-109vd24"
     data-chakra-component="CCheckbox"
     for="checkbox-1"
   >
     <input
-      class="css-0 css-f8n5zr"
+      class="css-fzcsno css-f8n5zr"
       data-chakra-component="CVisuallyHidden"
       id="checkbox-1"
       type="checkbox"
@@ -16,11 +16,11 @@ exports[`should render correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-j27u0o css-xkdust"
+      class="css-t7hqiq css-xkdust"
       data-chakra-component="CControlBox"
     >
       <svg
-        class="css-1dx9t0m css-y3asau"
+        class="css-tvanhj css-y3asau"
         data-chakra-component="CIcon"
         role="presentation"
         viewBox="0 0 14 14"

--- a/packages/chakra-ui-core/src/CCheckboxGroup/tests/__snapshots__/CCheckboxGroup.test.js.snap
+++ b/packages/chakra-ui-core/src/CCheckboxGroup/tests/__snapshots__/CCheckboxGroup.test.js.snap
@@ -3,26 +3,26 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-1v5z18m"
+    class="css-tfbmoi"
     data-chakra-component="CBox"
   >
     <div
-      class="css-0"
+      class="css-fzcsno"
       data-chakra-component="CCheckboxGroup"
       role="group"
     >
       <div
-        class="css-1x9mqzb"
+        class="css-de9qzh"
         data-chakra-component="CBox"
       >
         <label
-          class="css-1qf83f9"
+          class="css-109vd24"
           data-chakra-component="CCheckbox"
           data-testid="one"
           for="checkbox-1"
         >
           <input
-            class="css-0 css-f8n5zr"
+            class="css-fzcsno css-f8n5zr"
             data-chakra-component="CVisuallyHidden"
             id="checkbox-1"
             name="numbers-0"
@@ -31,11 +31,11 @@ exports[`should render correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-j27u0o css-hpvc67"
+            class="css-t7hqiq css-hpvc67"
             data-chakra-component="CControlBox"
           >
             <svg
-              class="css-1dx9t0m css-y3asau"
+              class="css-tvanhj css-y3asau"
               data-chakra-component="CIcon"
               role="presentation"
               viewBox="0 0 14 14"
@@ -66,18 +66,18 @@ exports[`should render correctly 1`] = `
         </label>
       </div>
       <div
-        class="css-1x9mqzb"
+        class="css-de9qzh"
         data-chakra-component="CBox"
       >
         <label
-          class="css-1qf83f9"
+          class="css-109vd24"
           data-chakra-component="CCheckbox"
           data-testid="two"
           for="checkbox-2"
         >
           <input
             aria-checked="true"
-            class="css-0 css-f8n5zr"
+            class="css-fzcsno css-f8n5zr"
             data-chakra-component="CVisuallyHidden"
             id="checkbox-2"
             name="numbers-1"
@@ -86,11 +86,11 @@ exports[`should render correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-j27u0o css-hpvc67"
+            class="css-t7hqiq css-hpvc67"
             data-chakra-component="CControlBox"
           >
             <svg
-              class="css-1dx9t0m css-y3asau"
+              class="css-tvanhj css-y3asau"
               data-chakra-component="CIcon"
               role="presentation"
               viewBox="0 0 14 14"
@@ -121,17 +121,17 @@ exports[`should render correctly 1`] = `
         </label>
       </div>
       <div
-        class="css-13o7eu2"
+        class="css-gewor6"
         data-chakra-component="CBox"
       >
         <label
-          class="css-1qf83f9"
+          class="css-109vd24"
           data-chakra-component="CCheckbox"
           data-testid="three"
           for="checkbox-3"
         >
           <input
-            class="css-0 css-f8n5zr"
+            class="css-fzcsno css-f8n5zr"
             data-chakra-component="CVisuallyHidden"
             id="checkbox-3"
             name="numbers-2"
@@ -140,11 +140,11 @@ exports[`should render correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-j27u0o css-hpvc67"
+            class="css-t7hqiq css-hpvc67"
             data-chakra-component="CControlBox"
           >
             <svg
-              class="css-1dx9t0m css-y3asau"
+              class="css-tvanhj css-y3asau"
               data-chakra-component="CIcon"
               role="presentation"
               viewBox="0 0 14 14"

--- a/packages/chakra-ui-core/src/CCircularProgress/tests/__snapshots__/CCircularProgress.test.js.snap
+++ b/packages/chakra-ui-core/src/CCircularProgress/tests/__snapshots__/CCircularProgress.test.js.snap
@@ -6,18 +6,18 @@ exports[`should render correctly 1`] = `
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="40"
-    class="css-12d21aj"
+    class="css-6in7jm"
     data-chakra-component="CCircularProgress"
     data-testid="CircularProgress"
     role="progressbar"
   >
     <svg
-      class="css-1hoc9jg"
+      class="css-1ku0poz"
       data-chakra-component="CBox"
       viewBox="55.55555555555556 55.55555555555556 111.11111111111111 111.11111111111111"
     >
       <circle
-        class="css-ykn8or"
+        class="css-zwmgr9"
         cx="111.11111111111111"
         cy="111.11111111111111"
         data-chakra-component="CBox"
@@ -27,7 +27,7 @@ exports[`should render correctly 1`] = `
         stroke-width="11.111111111111112"
       />
       <circle
-        class="css-19r75gt"
+        class="css-257ejp"
         cx="111.11111111111111"
         cy="111.11111111111111"
         data-chakra-component="CBox"

--- a/packages/chakra-ui-core/src/CCloseButton/tests/__snapshots__/CloseButton.test.js.snap
+++ b/packages/chakra-ui-core/src/CCloseButton/tests/__snapshots__/CloseButton.test.js.snap
@@ -4,12 +4,12 @@ exports[`should render correctly 1`] = `
 <DocumentFragment>
   <button
     aria-label="Close"
-    class="css-0 css-12btrym"
+    class="css-fzcsno css-iwel03"
     data-chakra-component="CCloseButton"
   >
     <svg
       aria-hidden="true"
-      class="css-xmst1h css-y3asau"
+      class="css-1d2a4q2 css-y3asau"
       data-chakra-component="CIcon"
       role="presentation"
       viewBox="0 0 24 24"

--- a/packages/chakra-ui-core/src/CCode/CCode.js
+++ b/packages/chakra-ui-core/src/CCode/CCode.js
@@ -12,6 +12,7 @@ import { useVariantColorWarning, forwardProps } from '../utils'
 import { baseProps } from '../config/props'
 
 import CBox from '../CBox'
+import { SNA } from '../config/props/props.types'
 
 /**
  * CCode component
@@ -25,11 +26,15 @@ const CCode = {
   name: 'CCode',
   inject: ['$chakraTheme', '$chakraColorMode'],
   props: {
+    ...baseProps,
     variantColor: {
       type: String,
       default: 'gray'
     },
-    ...baseProps
+    fontFamily: {
+      type: SNA,
+      default: 'mono'
+    }
   },
   computed: {
     theme () {
@@ -53,9 +58,9 @@ const CCode = {
       props: {
         as: 'code',
         display: 'inline-block',
-        fontFamily: 'mono',
         fontSize: 'sm',
         px: '0.2em',
+        fontFamily: 'mono',
         rounded: 'sm',
         ...this.badgeStyle,
         ...forwardProps(this.$props)

--- a/packages/chakra-ui-core/src/CCollapse/tests/__snapshots__/CCollapse.test.js.snap
+++ b/packages/chakra-ui-core/src/CCollapse/tests/__snapshots__/CCollapse.test.js.snap
@@ -3,11 +3,11 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-i6bazn"
+    class="css-qiuzxw"
     data-chakra-component="CCollapse"
   >
     <div
-      class="css-i6bazn"
+      class="css-qiuzxw"
       data-chakra-component="CBox"
     >
       content

--- a/packages/chakra-ui-core/src/CControlBox/tests/__snapshots__/CControlBox.test.js.snap
+++ b/packages/chakra-ui-core/src/CControlBox/tests/__snapshots__/CControlBox.test.js.snap
@@ -3,12 +3,12 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <label
-    class="css-1jfyukr"
+    class="css-1os9xgq"
     data-chakra-component="CBox"
     for="control-radio"
   >
     <input
-      class="css-0 css-f8n5zr"
+      class="css-fzcsno css-f8n5zr"
       data-chakra-component="CVisuallyHidden"
       data-testid="hiddenControl"
       id="control-radio"
@@ -17,12 +17,12 @@ exports[`should render correctly 1`] = `
      
     <div
       aria-hidden="true"
-      class="css-1nwx1xd css-1y5evcc"
+      class="css-1cs601l css-1y5evcc"
       data-chakra-component="CControlBox"
       data-testid="control"
     >
       <div
-        class="css-1ojhcd8"
+        class="css-1x1dlhn"
         data-chakra-component="CBox"
       />
     </div>

--- a/packages/chakra-ui-core/src/CDivider/tests/__snapshots__/CDivider.test.js.snap
+++ b/packages/chakra-ui-core/src/CDivider/tests/__snapshots__/CDivider.test.js.snap
@@ -4,7 +4,7 @@ exports[`should change orientation 1`] = `
 <DocumentFragment>
   <hr
     aria-orientation="vertical"
-    class="css-1n8n8cf"
+    class="css-8cfh0v"
     data-chakra-component="CDivider"
   />
 </DocumentFragment>
@@ -14,7 +14,7 @@ exports[`should render correctly 1`] = `
 <DocumentFragment>
   <hr
     aria-orientation="horizontal"
-    class="css-boncrs"
+    class="css-1onigce"
     data-chakra-component="CDivider"
   />
 </DocumentFragment>

--- a/packages/chakra-ui-core/src/CDrawer/tests/__snapshots__/CDrawer.test.js.snap
+++ b/packages/chakra-ui-core/src/CDrawer/tests/__snapshots__/CDrawer.test.js.snap
@@ -5,14 +5,14 @@ exports[`should render correctly 1`] = `
   <div>
     <div>
       <input
-        class="css-0 css-1l17jza"
+        class="css-fzcsno css-1l17jza"
         data-chakra-component="CInput"
         data-testid="inputOutsideDrawer"
         placeholder="Type here..."
       />
        
       <button
-        class="css-0 css-rup5mm"
+        class="css-fzcsno css-1240sfg"
         data-chakra-component="CButton"
         data-testid="buttonOutside"
         tabindex="0"
@@ -28,18 +28,18 @@ exports[`should render correctly 1`] = `
     id="modal-portal-1"
   >
     <div
-      class="css-0 css-79elbk"
+      class="css-fzcsno css-1w0sygx"
       data-chakra-component="CPseudoBox"
     >
       <div
         style="position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px;"
       >
         <div
-          class="css-l5w8ps"
+          class="css-1h6qt27"
           data-chakra-component="CDrawerOverlay"
         />
         <div
-          class="css-13c8a1c"
+          class="css-10qbeko"
           data-chakra-component="CModalContent"
           data-testid="overlay"
         >
@@ -55,14 +55,14 @@ exports[`should render correctly 1`] = `
           >
             <button
               aria-label="Close"
-              class="css-0 css-1xo4iay"
+              class="css-fzcsno css-7a13dy"
               data-chakra-component="CDrawerCloseButton"
               data-testid="close-btn"
               x-close-button=""
             >
               <svg
                 aria-hidden="true"
-                class="css-xmst1h css-y3asau"
+                class="css-1d2a4q2 css-y3asau"
                 data-chakra-component="CIcon"
                 role="presentation"
                 viewBox="0 0 24 24"
@@ -77,7 +77,7 @@ exports[`should render correctly 1`] = `
             </button>
              
             <header
-              class="css-kniazf"
+              class="css-cryb04"
               data-chakra-component="CModalHeader"
               id="drawer-1-header"
             >
@@ -85,12 +85,12 @@ exports[`should render correctly 1`] = `
             </header>
              
             <div
-              class="css-5m10fw"
+              class="css-1lxlfxt"
               data-chakra-component="CModalBody"
               id="drawer-1-body"
             >
               <input
-                class="css-0 css-1l17jza"
+                class="css-fzcsno css-1l17jza"
                 data-chakra-component="CInput"
                 data-testid="inputInsideDrawer"
                 placeholder="Type here..."
@@ -98,11 +98,11 @@ exports[`should render correctly 1`] = `
             </div>
              
             <footer
-              class="css-plnu2w"
+              class="css-1y6ww5m"
               data-chakra-component="CModalFooter"
             >
               <button
-                class="css-0 css-1tex3qd"
+                class="css-fzcsno css-7un9wl"
                 data-chakra-component="CButton"
                 tabindex="0"
                 type="button"
@@ -111,7 +111,7 @@ exports[`should render correctly 1`] = `
               </button>
                
               <button
-                class="css-0 css-2jmp8f"
+                class="css-fzcsno css-1pavye0"
                 data-chakra-component="CButton"
                 tabindex="0"
                 type="button"

--- a/packages/chakra-ui-core/src/CEditable/tests/__snapshots__/CEditable.test.js.snap
+++ b/packages/chakra-ui-core/src/CEditable/tests/__snapshots__/CEditable.test.js.snap
@@ -4,13 +4,13 @@ exports[`should render correctly - input 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="css-0"
+      class="css-fzcsno"
       data-chakra-component="CEditable"
     >
       <!---->
        
       <input
-        class="css-0 css-wl0j5d"
+        class="css-fzcsno css-s4w4he"
         data-chakra-component="CEditableInput"
         data-testid="input"
         id="editable-1"
@@ -26,11 +26,11 @@ exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="css-0"
+      class="css-fzcsno"
       data-chakra-component="CEditable"
     >
       <span
-        class="css-0 css-1fsaeka"
+        class="css-fzcsno css-1rdo2d4"
         data-chakra-component="CEditablePreview"
         data-testid="preview"
         tabindex="0"

--- a/packages/chakra-ui-core/src/CFlex/tests/__snapshots__/CFlex.test.js.snap
+++ b/packages/chakra-ui-core/src/CFlex/tests/__snapshots__/CFlex.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should change styles 1`] = `
 <DocumentFragment>
   <div
-    class="css-b93e9j"
+    class="css-ypce8f"
     data-chakra-component="CFlex"
     data-testid="flex"
   >
@@ -15,7 +15,7 @@ exports[`should change styles 1`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-k008qs"
+    class="css-zlhv1"
     data-chakra-component="CFlex"
     data-testid="flex"
   >

--- a/packages/chakra-ui-core/src/CFormControl/tests/__snapshots__/CFormControl.test.js.snap
+++ b/packages/chakra-ui-core/src/CFormControl/tests/__snapshots__/CFormControl.test.js.snap
@@ -3,12 +3,12 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CFormControl"
     role="group"
   >
     <label
-      class="css-3wkg7s"
+      class="css-1dyvyy6"
       data-chakra-component="CFormLabel"
       for="fname"
     >
@@ -16,7 +16,7 @@ exports[`should render correctly 1`] = `
     </label>
      
     <input
-      class="css-0 css-1l17jza"
+      class="css-fzcsno css-1l17jza"
       data-chakra-component="CInput"
       id="fname"
       placeholder="First name"

--- a/packages/chakra-ui-core/src/CGrid/test/__snapshots__/CGrid.test.js.snap
+++ b/packages/chakra-ui-core/src/CGrid/test/__snapshots__/CGrid.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should change gap 1`] = `
 <DocumentFragment>
   <div
-    class="css-1w4meme"
+    class="css-rj19mw"
     data-chakra-component="CGrid"
   >
     Grid Me
@@ -14,7 +14,7 @@ exports[`should change gap 1`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-lgj0h8"
+    class="css-18j4d10"
     data-chakra-component="CGrid"
   >
     Grid Me

--- a/packages/chakra-ui-core/src/CIcon/tests/__snapshots__/CIcon.test.js.snap
+++ b/packages/chakra-ui-core/src/CIcon/tests/__snapshots__/CIcon.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <svg
-    class="css-3vopgu css-y3asau"
+    class="css-10j094p css-y3asau"
     data-chakra-component="CIcon"
     role="presentation"
     viewBox="0 0 24 24"

--- a/packages/chakra-ui-core/src/CIconButton/tests/__snapshots__/CIconButton.test.js.snap
+++ b/packages/chakra-ui-core/src/CIconButton/tests/__snapshots__/CIconButton.test.js.snap
@@ -4,7 +4,7 @@ exports[`should change icon 1`] = `
 <DocumentFragment>
   <button
     aria-label="Phone"
-    class="css-0 css-1tcmof5"
+    class="css-fzcsno css-120g2o4"
     data-chakra-component="CIconButton"
     data-testid="btn"
     tabindex="0"
@@ -12,7 +12,7 @@ exports[`should change icon 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="css-iav4tc css-y3asau"
+      class="css-1bsnxqn css-y3asau"
       data-chakra-component="CIcon"
       role="presentation"
       viewBox="0 0 24 24"
@@ -34,7 +34,7 @@ exports[`should render correctly 1`] = `
 <DocumentFragment>
   <button
     aria-label="Phone"
-    class="css-0 css-1tcmof5"
+    class="css-fzcsno css-120g2o4"
     data-chakra-component="CIconButton"
     data-testid="btn"
     tabindex="0"
@@ -42,7 +42,7 @@ exports[`should render correctly 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="css-iav4tc css-y3asau"
+      class="css-1bsnxqn css-y3asau"
       data-chakra-component="CIcon"
       role="presentation"
       viewBox="0 0 14 14"

--- a/packages/chakra-ui-core/src/CImage/CImage.js
+++ b/packages/chakra-ui-core/src/CImage/CImage.js
@@ -50,12 +50,12 @@ const CImage = {
       const image = new window.Image()
       image.src = src
 
-      image.onload = event => {
+      image.onload = (event) => {
         this.hasLoaded = true
         this.$emit('load', event)
       }
 
-      image.onError = event => {
+      image.onError = (event) => {
         this.hasLoaded = false
         this.$emit('error', event)
       }
@@ -71,10 +71,10 @@ const CImage = {
     return h(CNoSsr, [
       h(CBox, {
         props: {
-          ...forwardProps(this.$props),
           as: 'img',
           w: this.size,
-          h: this.size
+          h: this.size,
+          ...forwardProps(this.$props)
         },
         domProps: {
           width: this.htmlWidth,

--- a/packages/chakra-ui-core/src/CModal/tests/__snapshots__/CModal.test.js.snap
+++ b/packages/chakra-ui-core/src/CModal/tests/__snapshots__/CModal.test.js.snap
@@ -5,14 +5,14 @@ exports[`should render correctly 1`] = `
   <div>
     <div>
       <input
-        class="css-0 css-1l17jza"
+        class="css-fzcsno css-1l17jza"
         data-chakra-component="CInput"
         data-testid="inputOutsideModal"
         placeholder="Type here..."
       />
        
       <button
-        class="css-0 css-rup5mm"
+        class="css-fzcsno css-1240sfg"
         data-chakra-component="CButton"
         data-testid="buttonOutside"
         tabindex="0"
@@ -28,18 +28,18 @@ exports[`should render correctly 1`] = `
     id="modal-portal-1"
   >
     <div
-      class="css-0 css-79elbk"
+      class="css-fzcsno css-1w0sygx"
       data-chakra-component="CPseudoBox"
     >
       <div
         style="position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px;"
       >
         <div
-          class="css-l5w8ps"
+          class="css-1h6qt27"
           data-chakra-component="CBox"
         />
         <div
-          class="css-aibg9d"
+          class="css-tj90gg"
           data-chakra-component="CModalContent"
         >
           <section
@@ -55,14 +55,14 @@ exports[`should render correctly 1`] = `
           >
             <button
               aria-label="Close"
-              class="css-0 css-1hoaduj"
+              class="css-fzcsno css-mf8t7z"
               data-chakra-component="CModalCloseButton"
               data-testid="close-btn"
               x-close-button=""
             >
               <svg
                 aria-hidden="true"
-                class="css-xmst1h css-y3asau"
+                class="css-1d2a4q2 css-y3asau"
                 data-chakra-component="CIcon"
                 role="presentation"
                 viewBox="0 0 24 24"
@@ -77,7 +77,7 @@ exports[`should render correctly 1`] = `
             </button>
              
             <header
-              class="css-kniazf"
+              class="css-cryb04"
               data-chakra-component="CModalHeader"
               id="modal-1-header"
             >
@@ -85,12 +85,12 @@ exports[`should render correctly 1`] = `
             </header>
              
             <div
-              class="css-5m10fw"
+              class="css-1lxlfxt"
               data-chakra-component="CModalBody"
               id="modal-1-body"
             >
               <input
-                class="css-0 css-1l17jza"
+                class="css-fzcsno css-1l17jza"
                 data-chakra-component="CInput"
                 data-testid="inputInsideModal"
                 placeholder="Type here..."
@@ -98,11 +98,11 @@ exports[`should render correctly 1`] = `
             </div>
              
             <footer
-              class="css-plnu2w"
+              class="css-1y6ww5m"
               data-chakra-component="CModalFooter"
             >
               <button
-                class="css-0 css-1tex3qd"
+                class="css-fzcsno css-7un9wl"
                 data-chakra-component="CButton"
                 tabindex="0"
                 type="button"
@@ -111,7 +111,7 @@ exports[`should render correctly 1`] = `
               </button>
                
               <button
-                class="css-0 css-2jmp8f"
+                class="css-fzcsno css-1pavye0"
                 data-chakra-component="CButton"
                 tabindex="0"
                 type="button"

--- a/packages/chakra-ui-core/src/CProgress/tests/__snapshots__/CProgress.test.js.snap
+++ b/packages/chakra-ui-core/src/CProgress/tests/__snapshots__/CProgress.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-1dbix8u"
+    class="css-w3ffhx"
     data-chakra-component="CProgress"
     data-testid="progress"
   >
@@ -11,7 +11,7 @@ exports[`should render correctly 1`] = `
       aria-valuemax="100"
       aria-valuemin="0"
       aria-valuenow="40"
-      class="css-1yrbyx1"
+      class="css-1dfb4kd"
       data-chakra-component="CProgressIndicator"
       role="progressbar"
     />

--- a/packages/chakra-ui-core/src/CPseudoBox/tests/__snapshots__/CPseudoBox.test.js.snap
+++ b/packages/chakra-ui-core/src/CPseudoBox/tests/__snapshots__/CPseudoBox.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should change the style 1`] = `
 <DocumentFragment>
   <div
-    class="css-0 css-mr4uxt"
+    class="css-fzcsno css-mr4uxt"
     data-chakra-component="CPseudoBox"
     data-testid="box"
   >
@@ -15,7 +15,7 @@ exports[`should change the style 1`] = `
 exports[`should display Box with type as header 1`] = `
 <DocumentFragment>
   <header
-    class="css-0 css-0"
+    class="css-fzcsno css-fzcsno"
     data-chakra-component="CPseudoBox"
     data-testid="box"
   >
@@ -27,7 +27,7 @@ exports[`should display Box with type as header 1`] = `
 exports[`should display Box with type as p 1`] = `
 <DocumentFragment>
   <p
-    class="css-0 css-0"
+    class="css-fzcsno css-fzcsno"
     data-chakra-component="CPseudoBox"
     data-testid="box"
   >
@@ -39,7 +39,7 @@ exports[`should display Box with type as p 1`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-0 css-0"
+    class="css-fzcsno css-fzcsno"
     data-chakra-component="CPseudoBox"
     data-testid="box"
   >

--- a/packages/chakra-ui-core/src/CRadio/tests/__snapshots__/CRadio.test.js.snap
+++ b/packages/chakra-ui-core/src/CRadio/tests/__snapshots__/CRadio.test.js.snap
@@ -3,22 +3,22 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <label
-    class="css-1qf83f9"
+    class="css-109vd24"
     data-chakra-component="CRadio"
   >
     <input
-      class="css-0 css-f8n5zr"
+      class="css-fzcsno css-f8n5zr"
       data-chakra-component="CVisuallyHidden"
       type="radio"
       value=""
     />
     <div
       aria-hidden="true"
-      class="css-1v9glee css-aufuif"
+      class="css-1ht8nam css-aufuif"
       data-chakra-component="CControlBox"
     >
       <span
-        class="css-1qfw50u"
+        class="css-1luw7uj"
         data-chakra-component="CBox"
       />
     </div>

--- a/packages/chakra-ui-core/src/CRadioButtonGroup/tests/__snapshots__/CRadioButtonGroup.test.js.snap
+++ b/packages/chakra-ui-core/src/CRadioButtonGroup/tests/__snapshots__/CRadioButtonGroup.test.js.snap
@@ -3,13 +3,13 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-0"
+    class="css-fzcsno"
     data-chakra-component="CRadioButtonGroup"
     role="radiogroup"
   >
     <button
       aria-checked="true"
-      class="css-0 css-1f3kv3a"
+      class="css-fzcsno css-bfua14"
       data-chakra-component="CButton"
       data-testid="item-1"
       role="radio"
@@ -19,7 +19,7 @@ exports[`should render correctly 1`] = `
       Custom Radio 1
     </button>
     <button
-      class="css-0 css-rup5mm"
+      class="css-fzcsno css-1240sfg"
       data-chakra-component="CButton"
       data-testid="item-2"
       role="radio"
@@ -29,7 +29,7 @@ exports[`should render correctly 1`] = `
       Custom Radio 2
     </button>
     <button
-      class="css-0 css-rup5mm"
+      class="css-fzcsno css-1240sfg"
       data-chakra-component="CButton"
       data-testid="item-3"
       role="radio"
@@ -40,7 +40,7 @@ exports[`should render correctly 1`] = `
     </button>
     <button
       aria-disabled="true"
-      class="css-0 css-rup5mm"
+      class="css-fzcsno css-1240sfg"
       data-chakra-component="CButton"
       data-testid="item-4"
       disabled="disabled"

--- a/packages/chakra-ui-core/src/CStat/tests/__snapshots__/CStat.test.js.snap
+++ b/packages/chakra-ui-core/src/CStat/tests/__snapshots__/CStat.test.js.snap
@@ -3,7 +3,7 @@
 exports[`"CStatArrow" should display corresponding icon for "type" prop 1`] = `
 <DocumentFragment>
   <div
-    class="css-hkmnjw"
+    class="css-i8ou7a"
     data-chakra-component="CStat"
   >
     <p
@@ -23,7 +23,7 @@ exports[`"CStatArrow" should display corresponding icon for "type" prop 1`] = `
       data-chakra-component="CText"
     >
       <svg
-        class="css-1nhh26u css-y3asau"
+        class="css-ata6yd css-y3asau"
         data-chakra-component="CStatArrow"
         role="presentation"
         viewBox="0 0 24 24"
@@ -48,7 +48,7 @@ exports[`"CStatArrow" should display corresponding icon for "type" prop 1`] = `
 exports[`"CStatArrow" should display corresponding icon for "type" prop 2`] = `
 <DocumentFragment>
   <div
-    class="css-hkmnjw"
+    class="css-i8ou7a"
     data-chakra-component="CStat"
   >
     <p
@@ -68,7 +68,7 @@ exports[`"CStatArrow" should display corresponding icon for "type" prop 2`] = `
       data-chakra-component="CText"
     >
       <svg
-        class="css-es9pvn css-y3asau"
+        class="css-4vpgj8 css-y3asau"
         data-chakra-component="CStatArrow"
         role="presentation"
         viewBox="0 0 24 24"
@@ -93,7 +93,7 @@ exports[`"CStatArrow" should display corresponding icon for "type" prop 2`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-hkmnjw"
+    class="css-i8ou7a"
     data-chakra-component="CStat"
   >
     <p

--- a/packages/chakra-ui-core/src/CSwitch/tests/__snapshots__/CSwitch.test.js.snap
+++ b/packages/chakra-ui-core/src/CSwitch/tests/__snapshots__/CSwitch.test.js.snap
@@ -3,21 +3,21 @@
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <label
-    class="css-l5ub9m"
+    class="css-810y7c"
     data-chakra-component="CSwitch"
   >
     <input
-      class="css-0 css-f8n5zr"
+      class="css-fzcsno css-f8n5zr"
       data-chakra-component="CVisuallyHidden"
       type="checkbox"
     />
     <div
       aria-hidden="true"
-      class="css-1yyoepi css-14rwhig"
+      class="css-1uokdbb css-14rwhig"
       data-chakra-component="CControlBox"
     >
       <div
-        class="css-4b8l73"
+        class="css-sht12m"
         data-chakra-component="CBox"
       />
     </div>

--- a/packages/chakra-ui-core/src/CTag/tests/__snapshots__/CTag.test.js.snap
+++ b/packages/chakra-ui-core/src/CTag/tests/__snapshots__/CTag.test.js.snap
@@ -3,20 +3,20 @@
 exports[`should display tag with custom element 1`] = `
 <DocumentFragment>
   <div
-    class="css-82qlwu"
+    class="css-1u7dvmo"
     data-chakra-component="CBox"
   >
     <div
-      class="css-0 css-1jxztok"
+      class="css-fzcsno css-1v8giig"
       data-chakra-component="CTag"
     >
       <div
-        class="css-ovunuj"
+        class="css-1cm55yf"
         data-chakra-component="CAvatar"
       >
         <div
           aria-label="Mesut Koca"
-          class="css-bbjn3h"
+          class="css-1wti8hy"
           data-chakra-component="CAvatarName"
         >
           MK
@@ -24,7 +24,7 @@ exports[`should display tag with custom element 1`] = `
       </div>
        
       <span
-        class="css-gbh5ji"
+        class="css-e1yiz6"
         data-chakra-component="CTagLabel"
       >
         Mesut
@@ -37,22 +37,22 @@ exports[`should display tag with custom element 1`] = `
 exports[`should display tag with right icon 1`] = `
 <DocumentFragment>
   <div
-    class="css-82qlwu"
+    class="css-1u7dvmo"
     data-chakra-component="CBox"
   >
     <div
-      class="css-0 css-1mwiunl"
+      class="css-fzcsno css-h304f4"
       data-chakra-component="CTag"
     >
       <span
-        class="css-gbh5ji"
+        class="css-e1yiz6"
         data-chakra-component="CTagLabel"
       >
         Green
       </span>
        
       <svg
-        class="css-10whti9 css-y3asau css-9r03b"
+        class="css-1w7qkv4 css-y3asau css-9r03b"
         data-chakra-component="CTagIcon"
         role="presentation"
         size="12px"
@@ -75,15 +75,15 @@ exports[`should display tag with right icon 1`] = `
 exports[`should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-82qlwu"
+    class="css-1u7dvmo"
     data-chakra-component="CBox"
   >
     <div
-      class="css-0 css-1mwiunl"
+      class="css-fzcsno css-h304f4"
       data-chakra-component="CTag"
     >
       <svg
-        class="css-10whti9 css-y3asau css-9r03b"
+        class="css-1w7qkv4 css-y3asau css-9r03b"
         data-chakra-component="CTagIcon"
         role="presentation"
         size="12px"
@@ -100,7 +100,7 @@ exports[`should render correctly 1`] = `
       </svg>
        
       <span
-        class="css-gbh5ji"
+        class="css-e1yiz6"
         data-chakra-component="CTagLabel"
       >
         Green

--- a/packages/chakra-ui-core/src/config/props/props.js
+++ b/packages/chakra-ui-core/src/config/props/props.js
@@ -77,7 +77,10 @@ const baseProps = {
   bgRepeat: SNA,
   borderWidth: SNA,
   fontWeight: SNA,
-  fontFamily: SNA,
+  fontFamily: {
+    type: SNA,
+    default: 'body'
+  },
   fontSize: SNA,
   fontStyle: SNA,
   textAlign: SNA,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Defaults `fontFamily` prop to `body`. This will allow components that do not specify the font-family prop to fallback to the body font.

Other components like the `CCode` component & `CText` as `kbd` specify the `fontFamily` prop value to `mono`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
