### PR TITLE
fix: aria documentation link modified

### DIFF
--- a/packages/chakra-ui-core/src/CAlert/accessibility.md
+++ b/packages/chakra-ui-core/src/CAlert/accessibility.md
@@ -1,6 +1,6 @@
 # Alert | Accessibility ♿️
 
-This report is adapted to list the [WAI-ARIA Authoring practices for Alerts](https://www.w3.org/TR/wai-aria-practices-1.2/#accordion) supported by Chakra UI for the `CAlert` component.
+This report is adapted to list the [WAI-ARIA Authoring practices for Alerts](https://www.w3.org/TR/wai-aria-practices-1.2/#alert) supported by Chakra UI for the `CAlert` component.
 
 ### Description
 An alert is an element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Dynamically rendered alerts are automatically announced by most screen readers, and in some operating systems, they may trigger an alert sound. It is important to note that, at this time, screen readers do not inform users of alerts that are present on the page before page load completes.


### PR DESCRIPTION
Proper aria documentation link for alert is needed
which now changed from accordion to alert in Calert Accessibility.md

Modified the url for aria documentation website.
## Description
Modifications: **From** https://www.w3.org/TR/wai-aria-practices-1.2/#accordion **to** https://www.w3.org/TR/wai-aria-practices-1.2/#alert

## Motivation and Context
It will help user to redirect at correct location of aria documentation website. 

## How Has This Been Tested?
Tested by visiting the existing remote branch, and now it's getting redirected to it's proper location.

## Types of changes
Just a typo fix in Accessibility.md file of CAlert Component.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
