### PR TITLE
docs: fix misspelled transform attribute

### DIFF
--- a/website/pages/box.mdx
+++ b/website/pages/box.mdx
@@ -47,7 +47,7 @@ import { CBox } from '@chakra-ui/vue';
           font-weight="semibold"
           letter-spacing="wide"
           font-size="xs"
-          text-sransform="uppercase"
+          text-transform="uppercase"
           ml="2"
         >
           {{ property.beds }} beds &bull; {{ property.baths }} baths


### PR DESCRIPTION
Fixes misspelled transform attribute in [Box docs](https://vue.chakra-ui.com/box).

## Screenshots
`sransform` should be `transform`
![image](https://user-images.githubusercontent.com/19362349/88162898-35a98080-cc12-11ea-9352-04c4931979e9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
