### PR TITLE
Docs: Fix "Edit this page" Link

### DIFF
--- a/website/components/FileContributors.vue
+++ b/website/components/FileContributors.vue
@@ -31,7 +31,7 @@ export default {
       return this.$route.path
     },
     filePath () {
-      return `website/docs${this.fileRoute}.mdx`
+      return `website/pages${this.fileRoute}.mdx`
     }
   }
 }


### PR DESCRIPTION
## Description
Fix "Edit this page on GitHub" link at the end of docs page.

## Motivation and Context
The "Edit this page on GitHub" link at the end of docs page leads to 404 page not found on GitHub.
Issue #278 