### PR TITLE
fix: CReset config prop type

### DIFF
--- a/packages/chakra-ui-core/src/CReset/CReset.js
+++ b/packages/chakra-ui-core/src/CReset/CReset.js
@@ -51,7 +51,7 @@ const CReset = {
     }
   },
   props: {
-    config: Object
+    config: Function
   },
   created () {
     const { color, bg, borderColor, placeholderColor } = this.styleConfig[this.colorMode]


### PR DESCRIPTION
Providing a config prop to `CReset` results in `[Vue warn]: Invalid prop: type check failed for prop "config". Expected Object, got Function` when a Function is passed in.

## Description
Changed config prop type from `Object` to `Function`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves Issue: #283 

## How Has This Been Tested?
No testing included.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
