### PR TITLE
chore(theme): Simplifying chakra.js structure

### DIFF
--- a/packages/nuxt-chakra/lib/plugin.js
+++ b/packages/nuxt-chakra/lib/plugin.js
@@ -1,12 +1,14 @@
 import Vue from 'vue'
 import { createClientDirective } from '@chakra-ui/vue/src/directives'
 
+const theme = <%= JSON.stringify(options.theme, null, 2) %>
+
 Vue.prototype.$chakra = {
-  theme: <%= JSON.stringify(options.theme, null, 2) %>,
+  theme,
   icons: <%= JSON.stringify(options.icons, null, 2) %>
 }
 
-Vue.directive('chakra', createClientDirective(<%= JSON.stringify(options.theme, null, 2) %>))
+Vue.directive('chakra', createClientDirective(theme))
 
 if (process.client) {
   // Toast


### PR DESCRIPTION
## Description
Centralizes theme in the `theme` constant instead of duplicating output into prototype and directive. Also, saves extra uses of JSON.stringify.

## Motivation and Context
Simplifies applied theme look at chakra.js file and saves some extra JSON.stringify uses.

## How Has This Been Tested?
Tested into a pure Nuxt+Chakra application.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
