### PR TITLE
fix(example): Injecting $chakraTheme

### DIFF
--- a/packages/nuxt-chakra/example/pages/index.vue
+++ b/packages/nuxt-chakra/example/pages/index.vue
@@ -107,7 +107,7 @@ import {
 
 export default {
   name: 'App',
-  inject: ['$chakraColorMode', '$toggleColorMode'],
+  inject: ['$chakraTheme', '$chakraColorMode', '$toggleColorMode'],
   components: {
     CBox,
     CButton,


### PR DESCRIPTION
Injecting $chakraTheme into index.vue

## Description
It fixes a bug found on `computed` section when setting `theme()` which was returning '$chakraTheme' is not a function.

## Motivation and Context
It's required to fix '$chakraTheme is not a function' on `theme` inside computed section.

## How Has This Been Tested?
Tested in a pure Nuxt+Chakra installation.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13435327/92966295-a9ffe380-f44d-11ea-8b22-d06694539166.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
