### PR TITLE
feat: include style props for flex grow and native border radius props

### DIFF
--- a/packages/chakra-ui-core/CHANGELOG.md
+++ b/packages/chakra-ui-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.6.3
+
+### Patch Changes
+
+- fix: includes missing style props for border-radius and flex-grow style declarations"
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/chakra-ui-core/package.json
+++ b/packages/chakra-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chakra-ui/vue",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Build Accessible and Responsive Vue.js websites and applications with speed ⚡️",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/chakra-ui-core/src/CFlex/CFlex.stories.js
+++ b/packages/chakra-ui-core/src/CFlex/CFlex.stories.js
@@ -22,3 +22,18 @@ storiesOf('UI | Flex', module)
       </CFlex>
     `
   }))
+  .add('Flex grow', () => ({
+    components: { CFlex, CBox, CText },
+    template: `
+      <CFlex align="center">
+        <CBox rounded-top="lg" p="3" w="20" mr="3" h="20" bg="blue.100">1</CBox>
+        <CBox rounded-right="lg" p="3" w="20" mr="3" h="20" bg="blue.100">2</CBox>
+        <CBox rounded-bottom="lg" p="3" w="20" mr="3" h="20" bg="blue.100">3</CBox>
+        <CBox rounded-right="lg" p="3" w="20" mr="3" h="20" bg="blue.100">4</CBox>
+        <CBox border-top-right-radius="lg" p="3" w="20" mr="3" h="20" bg="blue.100">5</CBox>
+        <CBox border-top-left-radius="lg" p="3" w="20" mr="3" h="20" bg="blue.100">6</CBox>
+        <CBox border-bottom-right-radius="lg" p="3" w="20" mr="3" h="20" bg="blue.100">7</CBox>
+        <CBox border-bottom-left-radius="lg" p="3" w="20" h="20" bg="blue.100">8</CBox>
+      </CFlex>
+    `
+  }))

--- a/packages/chakra-ui-core/src/CFlex/CFlex.stories.js
+++ b/packages/chakra-ui-core/src/CFlex/CFlex.stories.js
@@ -25,15 +25,16 @@ storiesOf('UI | Flex', module)
   .add('Flex grow', () => ({
     components: { CFlex, CBox, CText },
     template: `
-      <CFlex align="center">
-        <CBox rounded-top="lg" p="3" w="20" mr="3" h="20" bg="blue.100">1</CBox>
-        <CBox rounded-right="lg" p="3" w="20" mr="3" h="20" bg="blue.100">2</CBox>
-        <CBox rounded-bottom="lg" p="3" w="20" mr="3" h="20" bg="blue.100">3</CBox>
-        <CBox rounded-right="lg" p="3" w="20" mr="3" h="20" bg="blue.100">4</CBox>
-        <CBox border-top-right-radius="lg" p="3" w="20" mr="3" h="20" bg="blue.100">5</CBox>
-        <CBox border-top-left-radius="lg" p="3" w="20" mr="3" h="20" bg="blue.100">6</CBox>
-        <CBox border-bottom-right-radius="lg" p="3" w="20" mr="3" h="20" bg="blue.100">7</CBox>
-        <CBox border-bottom-left-radius="lg" p="3" w="20" h="20" bg="blue.100">8</CBox>
+      <CFlex w="600px" align="center">
+        <CBox flex-grow="2" w="10" mr="3" h="10" bg="blue.100">1</CBox>
+        <CBox rounded-top="lg" w="10" mr="3" h="10" bg="blue.100">1</CBox>
+        <CBox rounded-right="lg" w="10" mr="3" h="10" bg="blue.100">2</CBox>
+        <CBox rounded-bottom="lg" w="10" mr="3" h="10" bg="blue.100">3</CBox>
+        <CBox rounded-right="lg" w="10" mr="3" h="10" bg="blue.100">4</CBox>
+        <CBox border-top-right-radius="lg" w="10" mr="3" h="10" bg="blue.100">5</CBox>
+        <CBox border-top-left-radius="lg" w="10" mr="3" h="10" bg="blue.100">6</CBox>
+        <CBox border-bottom-right-radius="lg" w="10" mr="3" h="10" bg="blue.100">7</CBox>
+        <CBox border-bottom-left-radius="lg" w="10" h="10" bg="blue.100">8</CBox>
       </CFlex>
     `
   }))

--- a/packages/chakra-ui-core/src/config/props/props.js
+++ b/packages/chakra-ui-core/src/config/props/props.js
@@ -63,6 +63,10 @@ const baseProps = {
   borderLeft: SNA,
   borderRight: SNA,
   borderTop: SNA,
+  borderTopLeftRadius: SNA,
+  borderTopRightRadius: SNA,
+  borderBottomRightRadius: SNA,
+  borderBottomLeftRadius: SNA,
   borderBottom: SNA,
   shadow: SNA,
   backgroundColor: SNA,
@@ -158,7 +162,8 @@ const baseProps = {
   opacity: SNA,
   letterSpacing: SNA,
   flexShrink: SNA,
-  boxShadow: SNA
+  boxShadow: SNA,
+  flexGrow: SNA
 }
 
 export default baseProps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #303 

Includes missing style props for the following utilities:
```
flex-shrink
border-top-left-radius
border-top-right-radius
border-bottom-left-radius
border-bottom-right-radius
```

## How Has This Been Tested?
I still haven't yet found a way to test style properties. Rather than include tests for these on this pull request, I think we should have a specific convention first. Let me know if you have any thoughts about this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
