### PR TITLE
fix(creset): include font-family to global styles

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -37,13 +37,6 @@ import {
 } from '@fortawesome/free-brands-svg-icons'
 
 Vue.use(Chakra, {
-  extendTheme: {
-    fonts: {
-      heading: "'Comic Sans MS'",
-      body: "'Comic Sans MS'",
-      monospace: "'Comic Sans MS'"
-    }
-  },
   icons: {
     iconPack: 'fa',
     iconSet: {

--- a/packages/chakra-ui-core/src/CReset/CReset.js
+++ b/packages/chakra-ui-core/src/CReset/CReset.js
@@ -15,13 +15,15 @@ const defaultConfig = theme => ({
     color: theme.colors.gray[800],
     bg: undefined,
     borderColor: theme.colors.gray[200],
-    placeholderColor: theme.colors.gray[400]
+    placeholderColor: theme.colors.gray[400],
+    fontFamily: theme.fonts.body
   },
   dark: {
     color: theme.colors.whiteAlpha[900],
     bg: theme.colors.gray[800],
     borderColor: theme.colors.whiteAlpha[300],
-    placeholderColor: theme.colors.whiteAlpha[400]
+    placeholderColor: theme.colors.whiteAlpha[400],
+    fontFamily: theme.fonts.body
   }
 })
 
@@ -59,13 +61,14 @@ const CReset = {
     }
   },
   created () {
-    const { color, bg, borderColor, placeholderColor } = this.styleConfig[this.colorMode]
+    const { color, bg, borderColor, placeholderColor, fontFamily } = this.styleConfig[this.colorMode]
     useTailwindPreflight(this.theme)
     injectGlobal({
       html: {
         lineHeight: 1.5,
         color,
-        backgroundColor: bg
+        backgroundColor: bg,
+        fontFamily
       },
 
       '*, *::before, *::after': {

--- a/packages/chakra-ui-core/src/CReset/tests/CReset.test.js
+++ b/packages/chakra-ui-core/src/CReset/tests/CReset.test.js
@@ -29,7 +29,7 @@ describe('CReset.vue', () => {
     const cssResetConfig = (_, defaults) => {
       const { light } = defaults
       return {
-        ...defaults, light: { ...light, bg: 'pink', color: 'indigo' }
+        ...defaults, light: { ...light, bg: 'pink', color: 'indigo', fontFamily: "'Comic Sans MS'" }
       }
     }
 

--- a/packages/chakra-ui-core/src/CReset/tests/__snapshots__/CReset.test.js.snap
+++ b/packages/chakra-ui-core/src/CReset/tests/__snapshots__/CReset.test.js.snap
@@ -318,7 +318,7 @@ exports[`CReset.vue should accept config prop 1`] = `
     data-emotion="css"
   >
     
-    html{line-height:1.5;color:#1A202C;}
+    html{line-height:1.5;color:#1A202C;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";}
   </style>
   <style
     data-emotion="css"
@@ -366,7 +366,7 @@ exports[`CReset.vue should accept config prop 1`] = `
     data-emotion="css"
   >
     
-    html{line-height:1.5;color:indigo;background-color:pink;}
+    html{line-height:1.5;color:indigo;background-color:pink;font-family:'Comic Sans MS';}
   </style>
   <style
     data-emotion="css"
@@ -731,7 +731,7 @@ exports[`CReset.vue should inject global styles 1`] = `
     data-emotion="css"
   >
     
-    html{line-height:1.5;color:#1A202C;}
+    html{line-height:1.5;color:#1A202C;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";}
   </style>
   <style
     data-emotion="css"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #312 

## Description
Includes font family to global styles for `CReset` component.

## Motivation and Context
This includes the `font-family` provided to theme object.
```js
// In main.js

import Vue from "vue";
import Chakra, { CThemeProvider, CReset } from "@chakra-ui/vue";

Vue.use(Chakra, {
  extendTheme: {
    fonts: {
      body: "'Comic Sans MS'"
    }
  }
});

new Vue({
  el: "#app",
  render: (h) =>
    h(CThemeProvider, [
      h(CReset) // <-- Sets root font-family from the `extendTheme` option in the Chakra plugin.
   ])
}).$mount();
```

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/21237954/94341721-39a4b500-003e-11eb-8401-ee9a550e116f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
