### PR TITLE
fix: Update toast.mdx

### DIFF
--- a/website/pages/toast.mdx
+++ b/website/pages/toast.mdx
@@ -213,7 +213,7 @@ export default {
 | `isClosable`  | `boolean`                                                               | `false`  | If `true` adds a close button to the toast.                          |
 | `onClose`     | `function`                                                              |          | Callback function to close the toast.                                |
 | `description` | `string`                                                                |          | The description of the toast.                                        |
-| `status`      | `success`, `danger`, `warning`, `info`                                   |          | The status of the toast.                                             |
+| `status`      | `success`, `error`, `warning`, `info`                                   |          | The status of the toast.                                             |
 | `variant`     | `solid`, `subtle`, `left-accent`, `top-accent`                           |          | The variant of the toast.                                            |
 | `duration`    | `number`                                                                | `5000ms` | Duration before dismiss in milliseconds, or `null` to never dismiss. |
 | `position`    | `top`, `top-left`, `top-right`, `bottom`, `bottom-left`, `bottom-right`  | `bottom` | Position the toast will popup out from.                              |


### PR DESCRIPTION

## Description
I changed danger to error on toast status valid property

## Motivation and Context
The docs on toasts will be misleading as danger is not a valid property for status
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Using status = 'danger' emits an error in the console but using status and displays an unstyled toast = 'error' works fine 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
