### PR TITLE
docs(fix): Create a new stacking context for doc search form

### DIFF
--- a/website/components/AlgoliaSearch.vue
+++ b/website/components/AlgoliaSearch.vue
@@ -36,6 +36,8 @@
     as="form"
     v-bind="$attrs"
     align="center"
+    position="relative"
+    z-index="1"
     @submit.prevent
   >
     <c-input-group>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request attempts to fix #336.
It gives the `AlogilaSearch` component a new stacking context.

## Motivation and Context
It attempts to fix #336. 

## How Has This Been Tested?
Tested by running it locally on my machine. It doesn't touch any other components.

## Screenshots (if appropriate):

![form-fix](https://user-images.githubusercontent.com/32661241/94986492-782ff780-0589-11eb-876a-68547922aa20.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
