### PR TITLE
fix: Set ccollapse height to auto on enter complete, unless finalHeight wa…

### DIFF
--- a/packages/chakra-ui-core/src/CAccordion/CAccordion.stories.js
+++ b/packages/chakra-ui-core/src/CAccordion/CAccordion.stories.js
@@ -32,6 +32,7 @@ storiesOf('UI | Accordion', module)
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
           veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
           commodo consequat.
+        </CAccordionPanel>
       </CAccordionItem>
     </CAccordion>
     `

--- a/packages/chakra-ui-core/src/CTransition/Transition.js
+++ b/packages/chakra-ui-core/src/CTransition/Transition.js
@@ -486,7 +486,7 @@ const CAnimateHeight = {
           height: [this.initialHeight || 0, this.finalHeight || height],
           easing: this.enterEasing,
           duration: this.duration,
-          complete
+          complete: () => { el.style.height = this.finalHeight || 'auto' }
         })
       })
     },


### PR DESCRIPTION
Fixes #383. (Also a small fix to the CAccordion storyblock)

## Motivation and Context
Sets CCollapse to `height: auto` when `enter` is complete, unless `finalHeight` prop was specified

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
