### PR TITLE
docs: update vuepress docs with codesandbox starter

### DIFF
--- a/website/pages/with-vuepress.mdx
+++ b/website/pages/with-vuepress.mdx
@@ -74,7 +74,7 @@ export default ({
       }
     }
   })
-})
+}
 ```
 
 Now you can wrap your main application inside the Chakra `CThemeProvider` component by creating a layout wrapper in `theme/layouts/Layout.vue`.
@@ -105,7 +105,11 @@ export default {
 
 ## Using Chakra components
 
-_In your `App.vue` file._
+You can now use Chakra in your custom components for your theme in either your `theme/components` folder (available to other theme components),
+or your `theme/global-components` folder (available to your markdown pages as well as other components).
+Learn more about theme inheritance in the [Vuepress documentation](https://vuepress.vuejs.org/theme/inheritance.html#inheritance-strategy)
+
+_In your `my-component.vue` file._
 
 ```vue
 <template>
@@ -120,7 +124,7 @@ _In your `App.vue` file._
 import { CBox, CButton } from '@chakra-ui/vue'
 
 export default {
-  name: 'App',
+  name: 'MyComponent',
   components: {
     CBox,
     CButton
@@ -128,3 +132,13 @@ export default {
 }
 </script>
 ```
+
+### Vuepress Codesandbox Starters
+
+Here's a link to sample component starter with Nuxt.js
+
+- [Vuepress Starter](https://codesandbox.io/s/chakra-ui-vuepress-starter-qx4up)
+
+### Storybook Components
+
+You can also view all developed components in [Storybook](https://chakra-ui-vue.netlify.com)!


### PR DESCRIPTION
Added a new [vuepress codesandbox starter](https://codesandbox.io/s/chakra-ui-vuepress-starter-qx4up) for the vuepress chakra docs.

## Description

* Added link to codesandbox starter at the bottom of the page
* Clarified the "using chakra components" section to explain components in vuepress's theme inheritance
* Fixed a little extra `)` in the code sample

## Motivation and Context

This is intended to provide a clear way to get started with ChakraUI in a new or existing Vuepress project with a live example.

## How Has This Been Tested?

The starter can successfully render basic Chakra components without completely overriding the existing Vuepress theme.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/23695312/111253307-ee16af80-864d-11eb-8365-5f7133cf8059.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
