### PR TITLE
docs: Add missing ' at line 80

### DIFF
--- a/website/pages/image.mdx
+++ b/website/pages/image.mdx
@@ -78,7 +78,7 @@ Below is the correct way to `require` relative assets for the `CImage` and `CAva
 <c-image src="@/assets/path-to-img.jpg" />
 
 <!-- ✅ Correct -->
-<c-image :src="require('@/assets/path-to-img.jpg)" />
+<c-image :src="require('@/assets/path-to-img.jpg')" />
 ```
 
 ## Fallback support


### PR DESCRIPTION
Typo in docs, Image section.

## Description
There is a typo in the docs.

## Motivation and Context
There is a missing ' in this code snippet, after path-to-img.jpg.
`<c-image :src="require('@/assets/path-to-img.jpg)" />`

## How Has This Been Tested?
It's just a typo.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
