### PR TITLE
fix: add an unstyled variant to the c-button validators

### DIFF
--- a/.changeset/dull-rats-sort.md
+++ b/.changeset/dull-rats-sort.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/vue": patch
+---
+
+fix: add an unstyled variant to the c-button validators

--- a/packages/chakra-ui-core/src/CButton/utils/button.props.js
+++ b/packages/chakra-ui-core/src/CButton/utils/button.props.js
@@ -12,7 +12,7 @@ export const buttonProps = {
     type: String,
     default: 'solid',
     validator: value =>
-      value.match(/^(solid|outline|ghost|flat|link)$/)
+      value.match(/^(solid|outline|ghost|flat|link|unstyled)$/)
   },
   variantColor: {
     type: [String, Array],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes props validator issue with CBotton component, when variant set to “unstyled".

## Screenshots (if appropriate):
<img width="549" alt="Captura de pantalla 2021-07-12 a las 23 03 11" src="https://user-images.githubusercontent.com/931497/125357996-a9cfbd80-e368-11eb-9274-93ead494c3cd.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
