### PR TITLE
feat(types): add type exports for color mode & theme providers

### DIFF
--- a/packages/chakra-ui-core/types/index.d.ts
+++ b/packages/chakra-ui-core/types/index.d.ts
@@ -3,17 +3,35 @@ import { Theme } from "../../chakra-ui-theme/types"
 import useToast from "../src/CToast"
 import { ToastFactory } from '../src/CToast/CToast'
 
+type ChakraIcons = { [name: string]: Icon };
+
 declare module 'vue/types/vue' {
   export interface Vue {
     $toast: ToastFactory
     $chakra: {
       theme: Theme
-      icons: { [name: string]: Icon }
+      icons: ChakraIcons
     }
-    chakraColorMode: string
-    chakraToggleColorMode: string
   }
 }
+
+declare module '../src/CColorModeProvider' {
+  export interface Provides {
+    $chakraColorMode: () => 'light' | 'dark'
+    $toggleColorMode: () => void
+  }
+}
+
+declare module '../src/CThemeProvider' {
+  export interface Provides {
+    $chakraTheme: Theme
+    $chakraIcons: ChakraIcons
+    $chakraColorMode: () => 'light'
+  }
+}
+
+export { Provides as CColorModeProvides } from '../src/CColorModeProvider'
+export { Provides as CThemeProvides } from '../src/CThemeProvider'
 
 export const useToast: typeof useToast
 export const defaultTheme: Theme


### PR DESCRIPTION
Added type export declarations for the CColorModeProvider and CThemeProvider components, for use with TypeScript environments. Rather than declaring them on the central Vue object, the provided types can be imported; an example is below.

```TS
import { Inject } from 'nuxt-property-decorator'
import type { CThemeProvides } from '@chakra-ui/vue'

/* ... inside a class component: */
@Inject('$chakraTheme')
theme: CThemeProvides['$chakraTheme'];
```

For consistency, I have taken the properties `chakraColorMode` and `chakraToggleColorMode` out of the Vue interface declaration. They are not injected or set on the main Vue instance, so they shouldn't be declared on it either.

## Motivation and Context
A while ago I submitted a PR (#473) adding type declarations for chakra to the main Vue object. This PR is aimed at also providing types for the provided items from the `CColorModeProvider` and `CThemeProvider` components, so this package can be used without issue by Vue/Nuxt + TS users.

This PR fixes the last issues of #469 left over after #473.

## How Has This Been Tested?
The pre-push tests are failing on the develop branch anyways, so hard to check.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
