### PR TITLE
fix: support multiple paths in icons

### DIFF
--- a/packages/chakra-ui-core/src/utils/icons.js
+++ b/packages/chakra-ui-core/src/utils/icons.js
@@ -1,11 +1,11 @@
 import { merge } from 'lodash-es'
 
 /**
- * @param {String} pack
- * @param {Array} icon
+ * @param {String} prefix - prefix for the icon pack
+ * @param {Array} icon - icon definition
  * @returns {{path: string, viewBox: string, attrs: *}}
  */
-const createIcon = (pack, icon) => {
+const createIcon = (prefix, icon) => {
   const [w, h, content, svg, data, , attrs] = icon
   let path
 
@@ -21,12 +21,12 @@ const createIcon = (pack, icon) => {
     return `<g fill="currentColor" class="${prefix}-group">${paths.join('')}</g>`
   }
 
-  if (pack === 'fa') {
+  if (prefix.startsWith('fa')) {
     path = Array.isArray(data)
-      ? createGroupedPath(data, pack)
+      ? createGroupedPath(data, prefix.substr(0, 2))
       : createPath(data)
   } else {
-    path = pack.startsWith('fe') ? content : svg
+    path = prefix.startsWith('fe') ? content : svg
   }
 
   return {
@@ -38,17 +38,16 @@ const createIcon = (pack, icon) => {
 
 /**
  * @description Custom parse all Icons provided by user
- * @param {String} pack - the name of the icon pack being used (fe, fa, mdi, etc)
  * @param {Object} iconSet - Registered Icons object
  * @returns {Object}
  */
-const parseIcons = (pack, iconSet = {}) => {
+const parseIcons = (iconSet = {}) => {
   const parseIcon = (iconObject) => {
-    const { icon, iconName } = iconObject
+    const { icon, prefix, iconName } = iconObject
     // Is library icon
     if (icon) {
       return {
-        [`${iconName}`]: createIcon(pack, icon)
+        [`${iconName}`]: createIcon(prefix, icon)
       }
     } else {
       return {}
@@ -62,13 +61,12 @@ const parseIcons = (pack, iconSet = {}) => {
 
 /**
  * @description Parse Icon packs
- * @param {String} pack - the name of the icon pack being used (fe, fa, mdi, etc)
  * @param {Object} iconSet Registered Icon set
  * @returns {Object} Parsed pack icons object
  */
-export const parsePackIcons = (pack, iconSet) => {
+export const parsePackIcons = (iconSet) => {
   // TODO: Add support for other icon libraries
   // - Material Icons: these are string constants, and need lots of work
   // - Tailwind Icons (Hero icons)
-  return parseIcons(pack, iconSet)
+  return parseIcons(iconSet)
 }

--- a/packages/chakra-ui-core/src/utils/icons.js
+++ b/packages/chakra-ui-core/src/utils/icons.js
@@ -1,6 +1,24 @@
 import { merge } from 'lodash-es'
 
 /**
+ * @description Parse FontAwesome icon path
+ * @param {String|Array} path a single svg path, or array of paths
+ * @returns {String}
+ */
+const parseFontAwesomeIcon = (path) => {
+  // duotone icon
+  if (Array.isArray(path) && path.length === 2) {
+    const paths = path.map((d, idx) =>
+      `<path d="${d}" fill="currentColor" class="${idx ? 'fa-primary' : 'fa-secondary'}" />`
+    )
+
+    return `<defs><style>.fa-secondary{opacity:.4}</style></defs><g class="fa-group">${paths.join('')}</g>`
+  }
+
+  return `<path d="${path}" fill="currentColor" />`
+}
+
+/**
  * @description Custom parse all Icons provided by user
  * @param {Object} iconSet - Registered Icons object
  * @returns {Object}
@@ -14,7 +32,7 @@ const parseIcons = (iconSet = {}) => {
       return {
         [`${iconObject.iconName}`]: {
           path: iconObject.prefix.startsWith('fa')
-            ? `<path d="${path}" fill="currentColor" />`
+            ? parseFontAwesomeIcon(path)
             : iconObject.prefix.startsWith('fe')
               ? content
               : svg,


### PR DESCRIPTION
## Description
FontAwesome duotone icons require multiple path elements, as well as className defs, and a default style def for the opacity of fa-secondary.

Inspecting the duotone SVGs in the pro repo, the order is `path.fa-secondary -> path.fa-primary`. I'm also not 100% sure that the grouping (`g.fa-group`) is needed, and welcome any feedback.

## Motivation and Context
see #495

## How Has This Been Tested?
Tested via a local link `npm link /path/to/fork`, and checked the behavior in the browser.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9557399/138612759-ae2b26ae-ee56-4526-ac5b-428679565166.png)

Here is example output
```html
<svg data-chakra-component="CIcon" viewBox="0 0 640 512" role="presentation" class="css-5ffdf css-3vopgu css-0">
  <g class="fa-group">
    <defs>
      <style>.fa-secondary{opacity:.4}</style>
    </defs>
    <path d="OMMITTED" fill="currentColor" class="fa-secondary"></path>
    <path d="OMMITTED" fill="currentColor" class="fa-primary"></path>
  </g>
</svg>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
