### PR TITLE
fix: emit CInput events from inside a CInputGroup

### DIFF
--- a/packages/chakra-ui-core/src/CInputGroup/CInputGroup.js
+++ b/packages/chakra-ui-core/src/CInputGroup/CInputGroup.js
@@ -53,9 +53,7 @@ const CInputGroup = {
           const clone = cloneVNode(vnode, h)
           return h(clone.componentOptions.Ctor, {
             ...clone.data,
-            on: {
-              ...(clone.componentOptions.listeners || {})
-            },
+            on: (clone.componentOptions.listeners || {}),
             props: {
               ...(clone.data.props || {}),
               ...clone.componentOptions.propsData,

--- a/packages/chakra-ui-core/src/CInputGroup/CInputGroup.js
+++ b/packages/chakra-ui-core/src/CInputGroup/CInputGroup.js
@@ -53,7 +53,9 @@ const CInputGroup = {
           const clone = cloneVNode(vnode, h)
           return h(clone.componentOptions.Ctor, {
             ...clone.data,
-            ...(clone.componentOptions.listeners || {}),
+            on: {
+              ...(clone.componentOptions.listeners || {})
+            },
             props: {
               ...(clone.data.props || {}),
               ...clone.componentOptions.propsData,


### PR DESCRIPTION
## Description
I pass down the listeners of cinput components using the `on` option of the data object

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
it fixes issue: https://github.com/chakra-ui/chakra-ui-vue/issues/292

## How Has This Been Tested?

I tested my changes using `yarn storybook` and listening for the keypress event on the first event 
of the **With left and right addons** story of CInput

All unit test also where run before pushing my changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
