### PR TITLE
fix: Include CGridItem in type definitions

### DIFF
--- a/.changeset/dull-books-judge.md
+++ b/.changeset/dull-books-judge.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/vue": patch
+---
+
+Include CGridItem in type definitions

--- a/packages/chakra-ui-core/types/component.d.ts
+++ b/packages/chakra-ui-core/types/component.d.ts
@@ -58,6 +58,7 @@ export class CFormHelperText extends Vue {}
 export class CFormLabel extends Vue {}
 export class CFragment extends Vue {}
 export class CGrid extends Vue {}
+export class CGridItem extends Vue {}
 export class CHeading extends Vue {}
 export class CIcon extends Vue {}
 export class CIconButton extends Vue {}


### PR DESCRIPTION
## Description
We notices that the type definitions do not include CGridItem, which leads to false error messages in the IDE although everything works when run.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
