### PR TITLE
fix(menu): allow menu option group to use array prop

### DIFF
--- a/.changeset/large-birds-add.md
+++ b/.changeset/large-birds-add.md
@@ -1,0 +1,9 @@
+---
+'nuxt-js': minor
+'@chakra-ui/vue': minor
+'@chakra-ui/nuxt': minor
+'@chakra-ui/theme-vue': minor
+'chakra-ui-docs': minor
+---
+
+This PR fixes the error in the c-menu-option-group prop and allow the value prop to be passed as an array (#497)

--- a/packages/chakra-ui-core/src/CMenu/CMenu.stories.js
+++ b/packages/chakra-ui-core/src/CMenu/CMenu.stories.js
@@ -1,9 +1,29 @@
 import { storiesOf } from '@storybook/vue'
-import { CMenu, CFade, CMenuGroup, CMenuButton, CMenuList, CMenuOptionGroup, CImage, CMenuItemOption, CMenuItem, CMenuDivider, CIcon } from '..'
+import {
+  CMenu,
+  CFade,
+  CMenuGroup,
+  CMenuButton,
+  CMenuList,
+  CMenuOptionGroup,
+  CImage,
+  CMenuItemOption,
+  CMenuItem,
+  CMenuDivider,
+  CIcon
+} from '..'
 
 storiesOf('UI | Menu', module)
   .add('With internal state', () => ({
-    components: { CFade, CMenu, CMenuGroup, CMenuButton, CMenuList, CMenuItem, CMenuDivider },
+    components: {
+      CFade,
+      CMenu,
+      CMenuGroup,
+      CMenuButton,
+      CMenuList,
+      CMenuItem,
+      CMenuDivider
+    },
     template: `
       <CMenu v-slot="{ isOpen }" :close-on-blur="false">
         <CMenuButton right-icon="chevron-down" variantColor="pink">
@@ -26,7 +46,15 @@ storiesOf('UI | Menu', module)
     `
   }))
   .add('With letter navigation', () => ({
-    components: { CMenu, CMenuGroup, CMenuButton, CMenuList, CMenuItem, CMenuDivider, CIcon },
+    components: {
+      CMenu,
+      CMenuGroup,
+      CMenuButton,
+      CMenuList,
+      CMenuItem,
+      CMenuDivider,
+      CIcon
+    },
     template: `
     <CMenu>
       <CMenuButton
@@ -51,7 +79,16 @@ storiesOf('UI | Menu', module)
     `
   }))
   .add('With Menu Options', () => ({
-    components: { CMenu, CMenuGroup, CMenuButton, CMenuList, CMenuOptionGroup, CMenuItemOption, CMenuItem, CMenuDivider },
+    components: {
+      CMenu,
+      CMenuGroup,
+      CMenuButton,
+      CMenuList,
+      CMenuOptionGroup,
+      CMenuItemOption,
+      CMenuItem,
+      CMenuDivider
+    },
     template: `
       <CMenu :closeOnSelect="false">
         <CMenuButton variantColor="blue">
@@ -73,7 +110,17 @@ storiesOf('UI | Menu', module)
     `
   }))
   .add('Letter navigation', () => ({
-    components: { CMenu, CMenuGroup, CMenuButton, CImage, CMenuList, CMenuOptionGroup, CMenuItemOption, CMenuItem, CMenuDivider },
+    components: {
+      CMenu,
+      CMenuGroup,
+      CMenuButton,
+      CImage,
+      CMenuList,
+      CMenuOptionGroup,
+      CMenuItemOption,
+      CMenuItem,
+      CMenuDivider
+    },
     template: `
       <c-menu>
         <c-menu-button as="button" right-icon="chevron-down">
@@ -105,7 +152,15 @@ storiesOf('UI | Menu', module)
     `
   }))
   .add('No close on blur', () => ({
-    components: { CMenu, CMenuGroup, CMenuButton, CMenuList, CMenuItem, CMenuDivider, CIcon },
+    components: {
+      CMenu,
+      CMenuGroup,
+      CMenuButton,
+      CMenuList,
+      CMenuItem,
+      CMenuDivider,
+      CIcon
+    },
     template: `
     <CMenu :closeOnBlur="false">
       <CMenuButton as="Button" rightIcon="chevron-down">

--- a/packages/chakra-ui-core/src/CMenu/CMenuOption.js
+++ b/packages/chakra-ui-core/src/CMenu/CMenuOption.js
@@ -22,7 +22,7 @@ const CMenuItemOption = {
     type: String,
     isDisabled: Boolean,
     isChecked: Boolean,
-    value: [String, Number]
+    value: [String, Number, Array]
   },
   computed: {
     context () {
@@ -102,55 +102,63 @@ const CMenuItemOption = {
     }
   },
   render (h) {
-    return h(CPseudoBox, {
-      props: {
-        as: 'button'
-      },
-      attrs: {
-        ...this.menuItemStyles,
-        display: 'flex',
-        minHeight: '32px',
-        alignItems: 'center',
-        ...this.$attrs,
-        role: this.role,
-        tabindex: -1,
-        'aria-checked': this.isChecked,
-        disabled: this.isDisabled,
-        'aria-disabled': this.isDisabled,
-        'data-chakra-component': 'CMenuItemOption'
-      },
-      nativeOn: {
-        click: this.handleClick,
-        mouseenter: this.handleMouseEnter,
-        mouseleave: this.handleMouseLeave,
-        keydown: this.handleKeyDown
-      }
-    }, [
-      h(CIcon, {
+    return h(
+      CPseudoBox,
+      {
         props: {
-          name: 'check'
+          as: 'button'
         },
         attrs: {
-          opacity: this.isChecked ? 1 : 0,
-          color: 'currentColor',
-          size: '1em',
-          ml: '1rem',
-          mr: '-4px',
-          'aria-hidden': true,
-          'data-menuitem-icon': ''
-        }
-      }),
-      h(CBox, {
-        props: {
-          as: 'span'
+          ...this.menuItemStyles,
+          display: 'flex',
+          minHeight: '32px',
+          alignItems: 'center',
+          ...this.$attrs,
+          role: this.role,
+          tabindex: -1,
+          'aria-checked': this.isChecked,
+          disabled: this.isDisabled,
+          'aria-disabled': this.isDisabled,
+          'data-chakra-component': 'CMenuItemOption'
         },
-        attrs: {
-          textAlign: 'left',
-          flex: '1',
-          mx: '1rem'
+        nativeOn: {
+          click: this.handleClick,
+          mouseenter: this.handleMouseEnter,
+          mouseleave: this.handleMouseLeave,
+          keydown: this.handleKeyDown
         }
-      }, this.$slots.default)
-    ])
+      },
+      [
+        h(CIcon, {
+          props: {
+            name: 'check'
+          },
+          attrs: {
+            opacity: this.isChecked ? 1 : 0,
+            color: 'currentColor',
+            size: '1em',
+            ml: '1rem',
+            mr: '-4px',
+            'aria-hidden': true,
+            'data-menuitem-icon': ''
+          }
+        }),
+        h(
+          CBox,
+          {
+            props: {
+              as: 'span'
+            },
+            attrs: {
+              textAlign: 'left',
+              flex: '1',
+              mx: '1rem'
+            }
+          },
+          this.$slots.default
+        )
+      ]
+    )
   }
 }
 
@@ -173,7 +181,7 @@ const CMenuOptionGroup = {
     name: String,
     title: String,
     value: {
-      type: [String, Number],
+      type: [String, Number, Array],
       default: null
     },
     defaultValue: [String, Number, Array]
@@ -229,7 +237,9 @@ const CMenuOptionGroup = {
     if (!this.$slots || !this.$slots.default) {
       return h(null)
     } else if (!this.$slots.default.length) {
-      return console.error('[Chakra-ui]: <CMenuOptionGroup /> component expects at least one child node.')
+      return console.error(
+        '[Chakra-ui]: <CMenuOptionGroup /> component expects at least one child node.'
+      )
     }
 
     const children = this.$slots.default.filter(e => e.tag)
@@ -237,79 +247,94 @@ const CMenuOptionGroup = {
     const clonedChildNodes = children.map((vnode) => {
       let result
       const cloned = cloneVNode(vnode, h)
-      if (!cloned.componentOptions) return console.error('Chakra-ui: <CMenuOptionGroup /> component expects valid component as children')
+      if (!cloned.componentOptions)
+        return console.error(
+          'Chakra-ui: <CMenuOptionGroup /> component expects valid component as children'
+        )
 
       if (this.type === 'radio') {
-        result = h(cloned.componentOptions.Ctor, {
-          ...cloned.data,
-          props: {
-            ...(cloned.data.props || {}),
-            ...cloned.componentOptions.propsData,
-            type: this.type,
-            name: this.name || this.fallbackName,
-            isChecked: cloned.componentOptions.propsData.value === this.computedValue
-          },
-          attrs: {
-            ...(cloned.data.attrs || {})
-          },
-          key: cloned.componentOptions.propsData.value,
-          nativeOn: {
-            click: (event) => {
-              this.handleChange(cloned.componentOptions.propsData.value)
+        result = h(
+          cloned.componentOptions.Ctor,
+          {
+            ...cloned.data,
+            props: {
+              ...(cloned.data.props || {}),
+              ...cloned.componentOptions.propsData,
+              type: this.type,
+              name: this.name || this.fallbackName,
+              isChecked:
+                cloned.componentOptions.propsData.value === this.computedValue
             },
-            keydown: (event) => {
-              if (['Enter', ' '].includes(event.key)) {
-                event.preventDefault()
+            attrs: {
+              ...(cloned.data.attrs || {})
+            },
+            key: cloned.componentOptions.propsData.value,
+            nativeOn: {
+              click: (event) => {
                 this.handleChange(cloned.componentOptions.propsData.value)
+              },
+              keydown: (event) => {
+                if (['Enter', ' '].includes(event.key)) {
+                  event.preventDefault()
+                  this.handleChange(cloned.componentOptions.propsData.value)
+                }
               }
             }
-          }
-        }, cloned.componentOptions.children)
+          },
+          cloned.componentOptions.children
+        )
       }
 
       if (this.type === 'checkbox') {
-        result = h(cloned.componentOptions.Ctor, {
-          ...cloned.data,
-          props: {
-            ...(cloned.data.props || {}),
-            ...cloned.componentOptions.propsData,
-            type: this.type,
-            isChecked: this.computedValue.includes(cloned.componentOptions.propsData.value)
-          },
-          attrs: {
-            ...(cloned.data.attrs || {})
-          },
-          key: cloned.componentOptions.propsData.value,
-          nativeOn: {
-            click: (event) => {
-              this.handleChange(cloned.componentOptions.propsData.value)
+        result = h(
+          cloned.componentOptions.Ctor,
+          {
+            ...cloned.data,
+            props: {
+              ...(cloned.data.props || {}),
+              ...cloned.componentOptions.propsData,
+              type: this.type,
+              isChecked: this.computedValue.includes(
+                cloned.componentOptions.propsData.value
+              )
             },
-            keydown: (event) => {
-              if (['Enter', ' '].includes(event.key)) {
-                event.preventDefault()
+            attrs: {
+              ...(cloned.data.attrs || {})
+            },
+            key: cloned.componentOptions.propsData.value,
+            nativeOn: {
+              click: (event) => {
                 this.handleChange(cloned.componentOptions.propsData.value)
+              },
+              keydown: (event) => {
+                if (['Enter', ' '].includes(event.key)) {
+                  event.preventDefault()
+                  this.handleChange(cloned.componentOptions.propsData.value)
+                }
               }
             }
-          }
-        }, cloned.componentOptions.children)
+          },
+          cloned.componentOptions.children
+        )
       }
 
       return result
     })
 
-    return h(CMenuGroup, {
-      props: {
-        title: this.title
+    return h(
+      CMenuGroup,
+      {
+        props: {
+          title: this.title
+        },
+        attrs: {
+          ...this.$attrs,
+          'data-chakra-component': 'CMenuOptionGroup'
+        }
       },
-      attrs: {
-        ...this.$attrs,
-        'data-chakra-component': 'CMenuOptionGroup'
-      }
-    }, clonedChildNodes)
+      clonedChildNodes
+    )
   }
 }
 
-export {
-  CMenuItemOption,
-  CMenuOptionGroup
-}
+export { CMenuItemOption, CMenuOptionGroup }

--- a/packages/chakra-ui-core/src/utils/icons.js
+++ b/packages/chakra-ui-core/src/utils/icons.js
@@ -14,7 +14,7 @@ const createIcon = (prefix, icon) => {
   const createGroupedPath = (groups, prefix) => {
     const paths = groups.map((d, idx) =>
       createPath(d, {
-        className: idx ? `${prefix}-primary` : `${prefix}-secondary`,
+        className: idx ? `${prefix}-primary` : `${prefix}-secondary`
       })
     )
 
@@ -32,7 +32,7 @@ const createIcon = (prefix, icon) => {
   return {
     path,
     viewBox: `0 0 ${w} ${h}`,
-    attrs,
+    attrs
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The documentation says `CMenuOptionGroup` accepts a string, number, Array as a value of the `:value` attribute. However, when the array is passed, a warning is thrown in the console:

`Invalid prop: type check failed for prop "value". Expected String, Number, got Array`

However, the component itself works as expected.

This PR fixes the error and allow the value prop to be passed as an array.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #497 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested with Storybook and the error wasn't displayed on the console when the fix was applied
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
