### PR TITLE
fix: mode is not defined

### DIFF
--- a/packages/chakra-ui-nuxt/lib/plugin.js
+++ b/packages/chakra-ui-nuxt/lib/plugin.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { createClientDirective } from '@chakra-ui/vue/src/directives'
-import { localColorModeObserver as colorModeObserver } from '@chakra-ui/vue'
+import { localColorModeObserver as colorModeObserver, mode } from '@chakra-ui/vue'
 import { toCSSVar } from '@chakra-ui/styled-system'
 import { mergeWith as merge } from '@chakra-ui/utils'
 import defaultTheme from '@chakra-ui/theme-vue'


### PR DESCRIPTION
## Description
Import `mode` from '@chakra-ui/vue'

## Motivation and Context
Fix #500 

## Codesandbox
Previously when using `$mode` in @chakra-ui/nuxt: https://codesandbox.io/s/nifty-monad-8lyvj?file=/pages/index.vue:409-543
Fixed: https://codesandbox.io/s/chakra-ui-nuxt-demo-forked-gxw0m?file=/pages/index.vue:409-543