### PR TITLE
fix: Include all position values in CToast

### DIFF
--- a/packages/chakra-ui-core/src/CToast/CToast.d.ts
+++ b/packages/chakra-ui-core/src/CToast/CToast.d.ts
@@ -1,5 +1,5 @@
 interface ChakraToastOptions {
-  position?: 'bottom' | 'top' | 'right' | 'left'
+  position?: 'bottom' | 'top' | 'right' | 'left' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
   duration?: number
   render?: (options: { onClose?: VoidFunction, id: any }) => any
   title?: string


### PR DESCRIPTION
Refering to https://github.com/codebender828/breadstick#-using-different-positions, the type definition of CToast does not include all options.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Include all position values in CToast

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
