### PR TITLE
fix(canvas): update storybook preview decorator

### DIFF
--- a/.storybook/components/Canvas.vue
+++ b/.storybook/components/Canvas.vue
@@ -6,34 +6,41 @@
         :bg="colorMode === 'light' ? 'white' : 'gray.800'"
         :color="colorMode === 'light' ? 'gray.800' : 'gray.50'"
         class="root"
+        width="100vw"
+        height="100vh"
+        transition="all 0.2s ease-in-out"
       >
-        <CHeading mb="50px" pos="absolute" top="3" left="50%" transform="translateX(-50%)" as="h4">@chakra-ui/vue</CHeading>
-        <CReset />
-        <CButton
-          as="a"
-          target="_blank"
-          href="https://github.com/chakra-ui/chakra-ui-vue"
-          position="fixed"
-          top="3"
-          left="3"
-          shadow="sm"
-          left-icon="github"
+        <CFlex justify-content="space-between" padding="4">
+          <CHeading mb="50px" as="h4">@chakra-ui/vue</CHeading>
+          <CReset />
+          <CButton
+            as="a"
+            target="_blank"
+            href="https://github.com/chakra-ui/chakra-ui-vue"
+            shadow="sm"
+            left-icon="github"
+            order="-1"
+          >
+            Github
+          </CButton>
+          <CIconButton
+            :aria-label="
+              `Switch to ${colorMode === 'light' ? 'dark' : 'light'} mode`
+            "
+            variant="solid"
+            :icon="colorMode === 'light' ? 'sun' : 'moon'"
+            @click="toggleColorMode"
+          >
+          </CIconButton>
+        </CFlex>
+        <CFlex
+          class="wrapper"
+          flex-direction="column"
+          justify-content="center"
+          align-items="center"
         >
-          Github
-        </CButton>
-        <CIconButton
-          position="fixed"
-          top="3"
-          right="3"
-          :aria-label="`Switch to ${colorMode === 'light' ? 'dark' : 'light'} mode`"
-          variant="ghost"
-          :icon="colorMode === 'light' ? 'sun' : 'moon'"
-          @click="toggleColorMode"
-        >
-        </CIconButton>
-        <div class="wrapper">
           <slot />
-        </div>
+        </CFlex>
       </CBox>
     </CColorModeProvider>
   </CThemeProvider>
@@ -46,8 +53,10 @@ import {
   CReset,
   CButton,
   CBox,
+  CFlex,
   CIconButton,
-  CColorModeProvider } from '../../packages/chakra-ui-core/src'
+  CColorModeProvider
+} from '../../packages/chakra-ui-core/src'
 
 export default {
   name: 'Canvas',
@@ -57,32 +66,9 @@ export default {
     CReset,
     CButton,
     CBox,
+    CFlex,
     CIconButton,
     CColorModeProvider
   }
 }
 </script>
-
-<style lang="scss" scoped>
-html,
-body {
-  margin: 0
-}
-.root {
-  height: 100vh;
-  width: 100vw;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  transition: all 0.2s ease-in-out;
-  .wrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%
-  }
-}
-</style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the layout of the `Canvas` preview for storybook

## Motivation and Context
The layout is currently broken, where only the Chakra props in the components used are working, and the scoped scss in the style tag of `Canvas.vue`.

Removed the `style` tag and all css properties, and used them as props in the chakra components used, along with additional adjustments to ensure the header content doesn't overlap the rendered story content.

## How Has This Been Tested?
Ran Storybook with the changes and viewed various stories.

## Screenshots (if appropriate):
### Before:
![image](https://user-images.githubusercontent.com/65234762/164342144-61d24622-c67d-48a2-9c75-7d2a816f405a.png)
### After:
![image](https://user-images.githubusercontent.com/65234762/164342111-99047075-30cf-47c7-b715-5030838bd0b8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
