### PR TITLE
fix: alert dialog `leastDestructiveRef` prop type

### DIFF
--- a/packages/chakra-ui-core/src/CAlertDialog/CAlertDialog.js
+++ b/packages/chakra-ui-core/src/CAlertDialog/CAlertDialog.js
@@ -55,7 +55,7 @@ const CAlertDialog = {
       type: Function,
       default: () => null
     },
-    leastDestructiveRef: [HTMLElement, Object]
+    leastDestructiveRef: [HTMLElement, Object, String, Function]
   },
   render (h, { slots, props, data }) {
     return h(CModal, {

--- a/website/pages/alertdialog.mdx
+++ b/website/pages/alertdialog.mdx
@@ -120,4 +120,4 @@ exception is that it requires a `leastDestructiveRef` which is similar to the
 
 | Name                           | Type                              | Default | Description                                                   |
 | ------------------------------ | --------------------------------- | ------- | ------------------------------------------------------------- |
-| leastDestructiveRef (required) | `ref`, `selector` `Function: ref` |         | The least destructive action to get focus when dialog is open |
+| leastDestructiveRef (required) | `vm.$ref`, `() => vm.ref` or `CSS selector` |         | The least destructive action to get focus when dialog is open |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

The `AlertDialog` component's prop [leastDustructiveRef](https://vue.chakra-ui.com/alertdialog#props) should accept the same type as the `Modal` component's prop [initialFocusRef](https://vue.chakra-ui.com/modal#props).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When I pass a function that returns a ref to leastDustructiveRef, it works well but shows a prop type warning.
```
[Vue warn]: Invalid prop: type check failed for prop "leastDestructiveRef". Expected HTMLElement, Object, got Function 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran Storybook with the changes and viewed various stories.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
